### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.0] - Unreleased
+
 ## [0.2.3] - Unreleased
-
-## [0.2.2] - 2024-09-06
-
-### Added
-
-- Add a `reissue:branch` task to create a new branch for the next version
-- Add a `reissue:push` task to push the new branch to the remote repository
-
-### Fixed
-
-- Require the 'date' library in tests to ensure the Date constant is present
-- Ensure that `updated_paths` are always enumerable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.0] - Unreleased
 
+### Added
+
+- Add `push_reissue` option to control pushing changes to the remote repository.
+
+### Changed
+
+- Default behavior of _this_ gem's release is to push finalize without a branch.
+
 ## [0.2.3] - Unreleased

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    reissue (0.2.3)
+    reissue (0.3.0)
       rake
 
 GEM

--- a/Rakefile
+++ b/Rakefile
@@ -16,5 +16,5 @@ require_relative "lib/reissue/gem"
 
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/reissue/version.rb"
-  task.push_finalize = :branch
+  task.push_finalize = true
 end

--- a/lib/reissue/version.rb
+++ b/lib/reissue/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Reissue
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Push the finalize step by default.

Create a way to set `push_reissue` to make a branch for the new version bump.