### PR TITLE
Add retain_changelogs feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.1] - Unreleased
 
+### Added
+
+- Add `retain_changelogs` option to control how to retain the changelog files for the previous versions.
+
 ### Changed
 
 - Set the name of the `reissue:branch` argument to `branch_name` to be clearer.
 - Inject the constants in the `create` method.
+- Updated the tested Ruby version to 3.4.
 
 ## [0.3.0] - 2024-09-06
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Reissue::Task.create :your_name_and_namespace do |task|
   # Optional: The file to update with the new version number. Defaults to "CHANGELOG.md".
   task.changelog_file = "path/to/CHANGELOG.md"
 
+  # Optional: A Boolean, String, or Proc to retain the changelog files for the previous versions. Defaults to false.
+  # Setting to true will retain the changelog files in the "changelogs" directory.
+  # Setting to a String will use that path as the directory to retain the changelog files.
+  # The Proc receives a version hash and the changelog content.
+  task.retain_changelogs = ->(version, content) do
+    # your special retention logic
+  end
+  # or task.retain_changelogs = "path/to/changelogs"
+  # or task.retain_changelogs = true
+
   # Optional: Whether to commit the changes automatically. Defaults to true.
   task.commit = false
 

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -19,6 +19,7 @@ module Reissue
   def self.call(
     version_file:,
     changelog_file: "CHANGELOG.md",
+    retain_changelogs: false,
     segment: "patch",
     date: "Unreleased",
     changes: {},
@@ -29,7 +30,7 @@ module Reissue
     new_version = version_updater.call(segment, version_file:)
     if changelog_file
       changelog_updater = ChangelogUpdater.new(changelog_file)
-      changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:)
+      changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:, retain_changelogs:)
     end
     new_version
   end

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -51,8 +51,9 @@ module Reissue
   #
   # @param file [String] The path to the changelog file.
   # @param version_limit [Integer] The number of versions to retain in the changelog. Default: 2
-  def self.reformat(file, version_limit: 2)
+  # @param retain_changelogs [Boolean, String, Proc] Whether to retain the changelog files for the previous versions.
+  def self.reformat(file, version_limit: 2, retain_changelogs: false)
     changelog_updater = ChangelogUpdater.new(file)
-    changelog_updater.reformat(version_limit:)
+    changelog_updater.reformat(version_limit:, retain_changelogs:)
   end
 end

--- a/lib/reissue/changelog_updater.rb
+++ b/lib/reissue/changelog_updater.rb
@@ -58,10 +58,10 @@ module Reissue
     #
     # @param changelog_file [String] The path to the changelog file (default: @changelog_file).
     # @return [Hash] The parsed changelog.
-    def reformat(result_file = @changelog_file, version_limit: 2)
+    def reformat(result_file = @changelog_file, version_limit: 2, retain_changelogs: false)
       @changelog = Parser.parse(File.read(@changelog_file))
       changelog["versions"] = changelog["versions"].first(version_limit)
-      write(result_file)
+      write(result_file, retain_changelogs:)
       changelog
     end
 

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -142,7 +142,7 @@ module Reissue
         else
           args[:version_limit].to_i
         end
-        formatter.reformat(changelog_file, version_limit:)
+        formatter.reformat(changelog_file, version_limit:, retain_changelogs:)
       end
 
       desc "Finalize the changelog for an unreleased version to set the release date."

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -31,6 +31,11 @@ module Reissue
     # The path to the changelog file.
     attr_accessor :changelog_file
 
+    # Set to true to retain the changelog files for the previous versions.
+    # Default: false.
+    # Provide a callable to decide how to store the files.
+    attr_accessor :retain_changelogs
+
     # Additional paths to add to the commit.
     attr_writer :updated_paths
 
@@ -68,6 +73,7 @@ module Reissue
       @version_file = nil
       @updated_paths = []
       @changelog_file = "CHANGELOG.md"
+      @retain_changelogs = false
       @commit = true
       @commit_finalize = true
       @push_finalize = false

--- a/test/test_reissue.rb
+++ b/test/test_reissue.rb
@@ -38,6 +38,34 @@ class TestReissue < Minitest::Spec
       assert_match(/2021-01-01/, contents)
       assert_match(/New feature/, contents)
     end
+
+    it "retains changelog history when specified" do
+      fixture_version = File.expand_path("fixtures/version.rb", __dir__)
+      version_file = Tempfile.new
+      version_file << File.read(fixture_version)
+      version_file.close
+
+      fixture_changelog = File.expand_path("fixtures/changelog.md", __dir__)
+      changelog_file = Tempfile.new
+      changelog_file << File.read(fixture_changelog)
+      changelog_file.close
+
+      Dir.mktmpdir do |tempdir|
+        Reissue.call(
+          version_file:,
+          changelog_file: changelog_file.path,
+          retain_changelogs: tempdir,
+          segment: "major",
+          changes: {"Added" => ["New feature"]}
+        )
+
+        retained_file = File.join(tempdir, "1.0.0.md")
+        assert File.exist?(retained_file)
+        contents = File.read(retained_file)
+        assert_match(/\[1.0.0\]/, contents)
+        assert_match(/New feature/, contents)
+      end
+    end
   end
 
   describe ".finalize" do


### PR DESCRIPTION
This allows gems to specify that each version's changelog may be maintained in a separate
directory to keep a history of changes that he main changelog file may purge.