### PR TITLE
Create a changelog if none exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.0] - Unreleased
+
+### Changed
+
+- Update reformat task to create a new changelog if it doesn't exist
+
 ## [0.3.4] - Unreleased
 
 ## [0.3.3] - 2025-01-17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    reissue (0.3.4)
+    reissue (0.4.0)
       rake
 
 GEM

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -56,4 +56,34 @@ module Reissue
     changelog_updater = ChangelogUpdater.new(file)
     changelog_updater.reformat(version_limit:, retain_changelogs:)
   end
+
+  INITIAL_CHANGES = {
+    "Added" => ["Initial release"]
+  }
+
+  def self.generate_changelog(location, changes: {})
+    template = <<~EOF
+      # Changelog
+
+      All notable changes to this project will be documented in this file.
+
+      The format is based on [Keep a Changelog](http://keepachangelog.com/)
+      and this project adheres to [Semantic Versioning](http://semver.org/).
+
+      ## Unreleased
+
+      ## [0.1.0]
+    EOF
+
+    File.write(location, template)
+    changelog_updater = ChangelogUpdater.new(location)
+    changelog_updater.call(
+      "0.1.0",
+      date: "Unreleased",
+      changes: changes.empty? ? INITIAL_CHANGES : changes,
+      changelog_file: location,
+      version_limit: 1,
+      retain_changelogs: false
+    )
+  end
 end

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -142,6 +142,9 @@ module Reissue
         else
           args[:version_limit].to_i
         end
+        unless File.exist?(changelog_file)
+          formatter.generate_changelog(changelog_file)
+        end
         formatter.reformat(changelog_file, version_limit:, retain_changelogs:)
       end
 

--- a/lib/reissue/version.rb
+++ b/lib/reissue/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Reissue
-  VERSION = "0.3.4"
+  VERSION = "0.4.0"
 end

--- a/test/test_reissue.rb
+++ b/test/test_reissue.rb
@@ -144,4 +144,44 @@ class TestReissue < Minitest::Spec
       FIXED
     end
   end
+
+  describe ".generate_changelog" do
+    it "creates a new changelog file with initial content" do
+      changelog_file = Tempfile.new
+      version_file = Tempfile.new
+      version_file.write("module MyGem\n  VERSION = '0.1.0'\nend")
+      version_file.close
+
+      Reissue.generate_changelog(changelog_file.path)
+
+      contents = File.read(changelog_file)
+      assert_match(/Changelog/, contents)
+      assert_match(/Keep a Changelog/, contents)
+      assert_match(/Semantic Versioning/, contents)
+      assert_match(/Unreleased/, contents)
+      assert_match(/\[0.1.0\]/, contents)
+      assert_match(/Initial release/, contents)
+    end
+
+    it "accepts custom changes" do
+      changelog_file = Tempfile.new
+      version_file = Tempfile.new
+      version_file.write("module MyGem\n  VERSION = '0.1.0'\nend")
+      version_file.close
+
+      custom_changes = {
+        "Added" => ["Custom feature"],
+        "Fixed" => ["Bug fix"]
+      }
+
+      Reissue.generate_changelog(changelog_file.path, changes: custom_changes)
+
+      contents = File.read(changelog_file)
+      assert_match(/\[0.1.0\]/, contents)
+      assert_match(/### Added/, contents)
+      assert_match(/Custom feature/, contents)
+      assert_match(/### Fixed/, contents)
+      assert_match(/Bug fix/, contents)
+    end
+  end
 end


### PR DESCRIPTION
Using the reissue:reformat rake task you can now create a changelog.md if it does not exist.