### PR TITLE
Add OIDC role ID support for trusted publishing

### DIFF
--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -52,6 +52,10 @@ on:
         required: false
         default: false
         type: boolean
+      oidc_role_id:
+        description: 'RubyGems OIDC role ID for trusted publishing (required when use_trusted_publishing is true)'
+        required: false
+        type: string
     secrets:
       rubygems_api_key:
         description: 'RubyGems API key for publishing'
@@ -212,6 +216,7 @@ jobs:
         with:
           audience: "https://oidc-api-token.rubygems.org"
           gem-server: "https://oidc-api-token.rubygems.org"
+          role-to-assume: ${{ inputs.oidc_role_id }}
 
       - name: Release gem to RubyGems
         run: ${{ inputs.publish_command }}
@@ -323,6 +328,7 @@ jobs:
         with:
           audience: "https://oidc-api-token.rubygems.org"
           gem-server: "https://oidc-api-token.rubygems.org"
+          role-to-assume: ${{ inputs.oidc_role_id }}
 
       - name: Get current version before release
         id: current_version


### PR DESCRIPTION
## Summary

This PR adds support for RubyGems OIDC role IDs in the shared workflow to enable proper trusted publishing authentication.

## Changes

- Added `oidc_role_id` input parameter to the shared workflow
- Updated both `rubygems/configure-rubygems-credentials` action calls to include the `role-to-assume` parameter
- This allows each gem to specify its unique OIDC role ID obtained from RubyGems.org

## Why This Is Needed

RubyGems OIDC trusted publishing requires a specific role ID (like `rg_oidc_akr_7ooqz7zfa4xpqsvb42ec`) to authenticate. Without this parameter, trusted publishing fails with "Access Denied" errors.

## Usage Example

```yaml
jobs:
  release:
    uses: SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main
    with:
      gem_name: pundit-plus
      use_trusted_publishing: true
      oidc_role_id: rg_oidc_akr_7ooqz7zfa4xpqsvb42ec
```