### PR TITLE
Fix OIDC URLs to use rubygems.org domain

### DIFF
--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -214,8 +214,8 @@ jobs:
         if: inputs.use_trusted_publishing
         uses: rubygems/configure-rubygems-credentials@main
         with:
-          audience: "https://oidc-api-token.rubygems.org"
-          gem-server: "https://oidc-api-token.rubygems.org"
+          audience: "https://rubygems.org"
+          gem-server: "https://rubygems.org"
           role-to-assume: ${{ inputs.oidc_role_id }}
 
       - name: Release gem to RubyGems
@@ -326,8 +326,8 @@ jobs:
         if: inputs.use_trusted_publishing
         uses: rubygems/configure-rubygems-credentials@main
         with:
-          audience: "https://oidc-api-token.rubygems.org"
-          gem-server: "https://oidc-api-token.rubygems.org"
+          audience: "https://rubygems.org"
+          gem-server: "https://rubygems.org"
           role-to-assume: ${{ inputs.oidc_role_id }}
 
       - name: Get current version before release


### PR DESCRIPTION
## Summary

This PR fixes the OIDC configuration URLs that were causing DNS errors.

## Problem

The workflow was using `oidc-api-token.rubygems.org` which doesn't exist as a resolvable domain, causing:
```
Error: getaddrinfo ENOTFOUND oidc-api-token.rubygems.org
```

## Solution

Changed the OIDC configuration to use the standard `rubygems.org` domain:
- `audience: "https://rubygems.org"`
- `gem-server: "https://rubygems.org"`

## Testing

This should resolve the DNS errors when using trusted publishing with RubyGems.