### PR TITLE
Fix OIDC configuration to match RubyGems settings

### DIFF
--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -214,7 +214,7 @@ jobs:
         if: inputs.use_trusted_publishing
         uses: rubygems/configure-rubygems-credentials@main
         with:
-          audience: "https://rubygems.org"
+          audience: "rubygems.org"
           gem-server: "https://rubygems.org"
           role-to-assume: ${{ inputs.oidc_role_id }}
 
@@ -326,7 +326,7 @@ jobs:
         if: inputs.use_trusted_publishing
         uses: rubygems/configure-rubygems-credentials@main
         with:
-          audience: "https://rubygems.org"
+          audience: "rubygems.org"
           gem-server: "https://rubygems.org"
           role-to-assume: ${{ inputs.oidc_role_id }}
 


### PR DESCRIPTION
- Change audience from 'https://rubygems.org' to 'rubygems.org' (no https://)
- Keep gem-server as 'https://rubygems.org' (with https://)
- This matches the RubyGems OIDC access policy configuration