### PR TITLE
Add working_directory input for monorepo support

### DIFF
--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -22,6 +22,11 @@ on:
         description: 'Ruby version to use (defaults to .ruby-version or .tool-versions file)'
         required: false
         type: string
+      working_directory:
+        description: 'Directory containing the gem (for monorepos)'
+        required: false
+        type: string
+        default: '.'
     outputs:
       version:
         description: 'The version that was released'
@@ -69,8 +74,10 @@ jobs:
               fi
             done
           fi
+          working-directory: ${{ inputs.working_directory }}
 
       - name: Configure Bundler
+        working-directory: ${{ inputs.working_directory }}
         run: bundle config set frozen false
 
       - name: Install dependencies
@@ -87,6 +94,7 @@ jobs:
 
       - name: Debug state after finalize
         if: always()
+        working-directory: ${{ inputs.working_directory }}
         run: |
           echo "=== Git state after finalize ==="
           git branch --show-current
@@ -108,16 +116,28 @@ jobs:
 
       - name: Get version being released
         id: version
+        working-directory: ${{ inputs.working_directory }}
         run: |
           version=$(ls pkg/*.gem | head -1 | sed 's/.*-\([0-9][^-]*\)\.gem/\1/')
           echo "released=$version" >> $GITHUB_OUTPUT
 
+      - name: Configure trusted publishing credentials
+        if: inputs.dry_run != true
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
+
       - name: Release gem to RubyGems
         if: inputs.dry_run != true
-        uses: rubygems/release-gem@v1
+        working-directory: ${{ inputs.working_directory }}
+        run: bundle exec rake release
+
+      - name: Wait for release to propagate
+        if: inputs.dry_run != true
+        working-directory: ${{ inputs.working_directory }}
+        run: gem exec rubygems-await pkg/*.gem
 
       - name: Dry run - skip RubyGems publish
         if: inputs.dry_run == true
+        working-directory: ${{ inputs.working_directory }}
         run: echo "Dry run - would publish version ${{ steps.version.outputs.released }} to RubyGems"
 
       - name: Check for branch change after release
@@ -134,8 +154,9 @@ jobs:
       - name: Commit any uncommitted changes and create branch
         if: steps.release_branch.outputs.changed == 'false'
         id: manual_branch
+        working-directory: ${{ inputs.working_directory }}
         run: |
-          git add -A
+          git add -A .
           if ! git diff --cached --quiet; then
             branch_name="post-release/$(date +%Y%m%d%H%M%S)"
             git checkout -b "$branch_name"


### PR DESCRIPTION
## Summary

- Adds `working_directory` input to the shared release workflow for monorepo support
- Replaces `rubygems/release-gem@v1` action with explicit release steps to enable working directory control
- Scopes `git add` to only stage files within the gem directory

## Why

The `rubygems/release-gem` action does not support a `working-directory` parameter. To enable releasing gems from subdirectories in monorepos, the workflow now explicitly runs the underlying steps:

1. Configure trusted publishing credentials via `rubygems/configure-rubygems-credentials@v1.0.0`
2. Run `bundle exec rake release` with the working directory
3. Wait for propagation with `gem exec rubygems-await pkg/*.gem`

## Usage

```yaml
jobs:
  release:
    uses: ./.github/workflows/shared-ruby-gem-release.yml
    with:
      working_directory: 'gems/my-gem'
```

## Test plan

- [ ] Test release workflow with default working directory (`.`)
- [ ] Test release workflow with a subdirectory path in a monorepo setup