### PR TITLE
Fix Ruby 4.x bundler permissions issue on GitHub Actions

### DIFF
--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -52,13 +52,29 @@ jobs:
           fetch-tags: true
 
       - name: Set up Ruby
+        id: setup-ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby_version }}
-          bundler-cache: true
+          bundler-cache: false
+
+      - name: Fix Ruby 4.x bundler permissions
+        run: |
+          ruby_version="${{ steps.setup-ruby.outputs.ruby-version }}"
+          gems_dir="$RUNNER_TOOL_CACHE/Ruby/${ruby_version}/x64/lib/ruby/gems"
+          if [ -d "$gems_dir" ]; then
+            for dir in "$gems_dir"/*; do
+              if [ -d "$dir" ]; then
+                chmod +t "$dir" 2>/dev/null || true
+              fi
+            done
+          fi
 
       - name: Configure Bundler
         run: bundle config set frozen false
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Record starting branch
         id: start


### PR DESCRIPTION
## Summary

Fixes the Ruby 4.0.1 bundler permissions issue that causes "unsafe to remove" errors on GitHub Actions.

## Business Justification

Unblocks releases for gems using Ruby 4.0.1, which was failing with bundler permission errors during the install step.

## Technical Details

Ruby 4.0.1 on GitHub Actions has a known issue where the gems directory (`/opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/gems/4.0.0/gems`) is world-writable without the sticky bit set. Bundler refuses to reinstall gems in this configuration for security reasons.

**Changes:**
- Disable `bundler-cache` in setup-ruby to control install timing
- Add step to set sticky bit (`chmod +t`) on gems directory before bundle install
- Add explicit `bundle install` step

**Example error this fixes:**
```
Bundler cannot reinstall erb-6.0.1 because there's a previous installation of it
at /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/gems/4.0.0/gems/erb-6.0.1 that
is unsafe to remove.
The parent of ... is world-writable and does not have the sticky bit set
```

**Integration with working-directory-support branch:**
After this PR merges, the `working-directory-support` branch will need to add `working-directory: ${{ inputs.working_directory }}` to the new "Install dependencies" step.

**Reference:** Failed run at https://github.com/SOFware/sof-ui/actions/runs/21719268461/job/62644019865