### PR TITLE
Make finalize task resilient to already-committed changelogs

### DIFF
--- a/test/test_rake_finalize_branch_naming.rb
+++ b/test/test_rake_finalize_branch_naming.rb
@@ -68,6 +68,91 @@ class TestRakeBranchNaming < Minitest::Test
     end
   end
 
+  def test_finalize_skips_commit_when_nothing_to_commit
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_changelog("0.4.5")
+
+        create_rakefile
+        load "Rakefile"
+
+        # Run finalize once to commit the formatted changelog
+        capture_io do
+          Rake::Task["reissue:finalize"].invoke("2025-11-21")
+        end
+
+        # Go back to main and re-apply the finalized changelog
+        system("git checkout main", out: File::NULL, err: File::NULL)
+        system("git merge finalize/0.4.5 --no-edit", out: File::NULL, err: File::NULL)
+
+        # Reset rake and reload
+        Rake.application.clear
+        @rake = Rake::Application.new
+        Rake.application = @rake
+        create_rakefile
+        load "Rakefile"
+
+        # Running finalize again should not raise
+        output, = capture_io do
+          Rake::Task["reissue:finalize"].invoke("2025-11-21")
+        end
+
+        assert_match(/Finalize the changelog/, output)
+      end
+    end
+  end
+
+  def test_finalize_stages_updated_paths
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_changelog("0.4.5")
+
+        # Pre-finalize the changelog so it's already committed
+        changelog = File.read("CHANGELOG.md")
+        changelog.sub!("Unreleased", "2025-11-21")
+        File.write("CHANGELOG.md", changelog)
+        system("git add -u", out: File::NULL, err: File::NULL)
+        system("git commit -m 'Already finalized'", out: File::NULL, err: File::NULL)
+
+        # Create an uncommitted checksums file
+        File.write("checksums", "SHA256 some-checksum")
+        system("git add checksums", out: File::NULL, err: File::NULL)
+        system("git commit -m 'Track checksums'", out: File::NULL, err: File::NULL)
+        File.write("checksums", "SHA256 updated-checksum")
+
+        # Create Rakefile with updated_paths including checksums
+        File.write("Rakefile", <<~RUBY)
+          require "reissue/rake"
+
+          Reissue::Task.create :reissue do |task|
+            task.version_file = "version.rb"
+            task.fragment = :git
+            task.push_finalize = :branch
+            task.push_reissue = :branch
+            task.updated_paths = ["checksums"]
+          end
+
+          Rake::Task["reissue:push"].clear
+          task "reissue:push" do
+          end
+        RUBY
+        load "Rakefile"
+
+        capture_io do
+          Rake::Task["reissue:finalize"].invoke("2025-11-21")
+        end
+
+        # Verify the checksums file was committed
+        log_output = `git log --oneline -1`.strip
+        assert_match(/Finalize the changelog/, log_output)
+
+        # Verify checksums was included in the commit
+        diff_output = `git show --name-only --format="" HEAD`.strip
+        assert_includes diff_output, "checksums"
+      end
+    end
+  end
+
   def test_finalize_and_reissue_use_different_prefixes
     # This test documents that finalize uses "finalize/" prefix
     # and reissue uses "reissue/" prefix, preventing branch name conflicts


### PR DESCRIPTION
Stage updated_paths (e.g. checksums) during finalize and skip
the commit gracefully when there are no staged changes.

Fixed: Finalize task fails when changelog is already committed
Fixed: Checksums not staged during finalize task