### PR TITLE
Fix working-directory placement in release workflow

### DIFF
--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -64,6 +64,7 @@ jobs:
           bundler-cache: false
 
       - name: Fix Ruby 4.x bundler permissions
+        working-directory: ${{ inputs.working_directory }}
         run: |
           ruby_version="${{ steps.setup-ruby.outputs.ruby-version }}"
           gems_dir="$RUNNER_TOOL_CACHE/Ruby/${ruby_version}/x64/lib/ruby/gems"
@@ -74,7 +75,6 @@ jobs:
               fi
             done
           fi
-          working-directory: ${{ inputs.working_directory }}
 
       - name: Configure Bundler
         working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
The working-directory key was inside the run block, causing
bash to execute it as a shell command.

Fixed: Release workflow fails with working-directory command not found