### PR TITLE
Add Hoe plugin for Reissue

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,28 @@ Additional tasks (usually run automatically):
 - `rake reissue:preview` - Preview changelog entries from fragments or git trailers
 - `rake reissue:clear_fragments` - Clear changelog fragments after release
 
+### Hoe Projects
+
+If you use [Hoe](https://github.com/seattlerb/hoe) for project management:
+
+```ruby
+Hoe.plugin :reissue
+
+Hoe.spec "my_gem" do
+  developer "Jane Doe", "jane@example.com"
+
+  self.reissue_version_file = "lib/my_gem/version.rb"
+  self.reissue_fragment = :git
+  self.reissue_push_finalize = :branch
+end
+```
+
+This hooks into Hoe's release lifecycle:
+- `prerelease` - Runs `reissue:bump` and `reissue:finalize` before release
+- `postrelease` - Runs `reissue` to bump version for the next development cycle
+
+All configuration options are available as `reissue_`-prefixed attributes (e.g., `reissue_version_file`, `reissue_changelog_file`). The version file defaults to `lib/#{name}/version.rb`.
+
 ### Non-Gem Projects
 
 For non-gem Ruby projects, add to your Rakefile:

--- a/lib/hoe/reissue.rb
+++ b/lib/hoe/reissue.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "reissue/rake"
+
+module Hoe::Reissue
+  attr_accessor :reissue_version_file, :reissue_changelog_file,
+    :reissue_version_limit, :reissue_version_redo_proc,
+    :reissue_fragment, :reissue_clear_fragments,
+    :reissue_retain_changelogs, :reissue_tag_pattern,
+    :reissue_commit, :reissue_commit_finalize,
+    :reissue_push_finalize, :reissue_push_reissue,
+    :reissue_updated_paths
+
+  def initialize_reissue
+    self.reissue_version_file = "lib/#{name}/version.rb"
+    self.reissue_changelog_file = "CHANGELOG.md"
+    self.reissue_version_limit = 2
+    self.reissue_version_redo_proc = nil
+    self.reissue_fragment = nil
+    self.reissue_clear_fragments = false
+    self.reissue_retain_changelogs = false
+    self.reissue_tag_pattern = nil
+    self.reissue_commit = true
+    self.reissue_commit_finalize = true
+    self.reissue_push_finalize = false
+    self.reissue_push_reissue = :branch
+    self.reissue_updated_paths = []
+  end
+
+  def define_reissue_tasks
+    config = {
+      version_file: reissue_version_file,
+      changelog_file: reissue_changelog_file,
+      version_limit: reissue_version_limit,
+      version_redo_proc: reissue_version_redo_proc,
+      fragment: reissue_fragment,
+      clear_fragments: reissue_clear_fragments,
+      retain_changelogs: reissue_retain_changelogs,
+      tag_pattern: reissue_tag_pattern,
+      commit: reissue_commit,
+      commit_finalize: reissue_commit_finalize,
+      push_finalize: reissue_push_finalize,
+      push_reissue: reissue_push_reissue,
+      updated_paths: reissue_updated_paths
+    }
+
+    Reissue::Task.create :reissue do
+      config.each { |attr, value| send(:"#{attr}=", value) }
+    end
+
+    Rake::Task.define_task(prerelease: ["reissue:bump", "reissue:finalize"])
+    Rake::Task.define_task(postrelease: ["reissue"])
+  end
+end

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -460,6 +460,19 @@ namespace :reissue do
     puts "This automatically runs reissue:bump and reissue:finalize before `rake build`"
     puts "and runs reissue after `rake release`."
     puts
+    puts "For Hoe-based projects, use the Hoe plugin:"
+    puts
+    puts <<~HOE_USAGE
+      Hoe.plugin :reissue
+
+      Hoe.spec "your_gem" do
+        self.reissue_version_file = "lib/your_gem/version.rb"
+        self.reissue_fragment = :git
+      end
+    HOE_USAGE
+    puts
+    puts "This hooks into Hoe's prerelease and postrelease tasks."
+    puts
     puts "Run `rake -T reissue` to see all available tasks after configuration."
   end
 end

--- a/test/test_hoe_integration.rb
+++ b/test/test_hoe_integration.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+require "tmpdir"
+
+# Hoe is normally a class defined by the hoe gem. We stub it here so the
+# plugin module can be loaded without requiring the full hoe dependency.
+module Hoe; end unless defined?(Hoe)
+
+require "hoe/reissue"
+
+class TestHoeIntegration < Minitest::Test
+  def setup
+    @rake = Rake::Application.new
+    Rake.application = @rake
+  end
+
+  def teardown
+    Rake.application.clear
+  end
+
+  def test_plugin_module_defines_expected_methods
+    assert_method_defined Hoe::Reissue, :initialize_reissue
+    assert_method_defined Hoe::Reissue, :define_reissue_tasks
+  end
+
+  def test_plugin_defines_reissue_tasks
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo("0.1.0")
+
+        plugin = Object.new
+        plugin.extend(Hoe::Reissue)
+        plugin.define_singleton_method(:name) { "my_gem" }
+        plugin.initialize_reissue
+        plugin.define_reissue_tasks
+
+        assert Rake::Task.task_defined?("reissue")
+        assert Rake::Task.task_defined?("reissue:finalize")
+        assert Rake::Task.task_defined?("reissue:preview")
+        assert Rake::Task.task_defined?("reissue:bump")
+        assert Rake::Task.task_defined?("reissue:reformat")
+      end
+    end
+  end
+
+  def test_plugin_enhances_prerelease_task
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo("0.1.0")
+
+        Rake::Task.define_task(:prerelease)
+        Rake::Task.define_task(:postrelease)
+
+        plugin = Object.new
+        plugin.extend(Hoe::Reissue)
+        plugin.define_singleton_method(:name) { "my_gem" }
+        plugin.initialize_reissue
+        plugin.define_reissue_tasks
+
+        prereqs = Rake::Task[:prerelease].prerequisites
+        assert_includes prereqs, "reissue:bump"
+        assert_includes prereqs, "reissue:finalize"
+      end
+    end
+  end
+
+  def test_plugin_enhances_postrelease_task
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo("0.1.0")
+
+        Rake::Task.define_task(:prerelease)
+        Rake::Task.define_task(:postrelease)
+
+        plugin = Object.new
+        plugin.extend(Hoe::Reissue)
+        plugin.define_singleton_method(:name) { "my_gem" }
+        plugin.initialize_reissue
+        plugin.define_reissue_tasks
+
+        prereqs = Rake::Task[:postrelease].prerequisites
+        assert_includes prereqs, "reissue"
+      end
+    end
+  end
+
+  def test_initialize_sets_defaults
+    plugin = Object.new
+    plugin.extend(Hoe::Reissue)
+    plugin.define_singleton_method(:name) { "my_gem" }
+    plugin.initialize_reissue
+
+    assert_equal "lib/my_gem/version.rb", plugin.reissue_version_file
+    assert_equal "CHANGELOG.md", plugin.reissue_changelog_file
+    assert_equal 2, plugin.reissue_version_limit
+    assert_nil plugin.reissue_version_redo_proc
+    assert_nil plugin.reissue_fragment
+    assert_equal false, plugin.reissue_clear_fragments
+    assert_equal false, plugin.reissue_retain_changelogs
+    assert_nil plugin.reissue_tag_pattern
+    assert_equal true, plugin.reissue_commit
+    assert_equal true, plugin.reissue_commit_finalize
+    assert_equal false, plugin.reissue_push_finalize
+    assert_equal :branch, plugin.reissue_push_reissue
+    assert_equal [], plugin.reissue_updated_paths
+  end
+
+  def test_config_passed_through_to_task_instance
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo("0.1.0")
+
+        plugin = Object.new
+        plugin.extend(Hoe::Reissue)
+        plugin.define_singleton_method(:name) { "my_gem" }
+        plugin.initialize_reissue
+        plugin.reissue_fragment = :git
+        plugin.reissue_commit = false
+        plugin.reissue_version_limit = 5
+        plugin.reissue_push_finalize = :branch
+        plugin.reissue_updated_paths = ["checksums"]
+        plugin.define_reissue_tasks
+
+        task_instance = ObjectSpace.each_object(Reissue::Task).find { |t|
+          t.version_file == "lib/my_gem/version.rb" && t.version_limit == 5
+        }
+
+        refute_nil task_instance, "Expected a Reissue::Task instance to be created"
+        assert_equal :git, task_instance.fragment
+        assert_equal false, task_instance.commit
+        assert_equal 5, task_instance.version_limit
+        assert_equal :branch, task_instance.push_finalize
+        assert_includes task_instance.updated_paths, "checksums"
+      end
+    end
+  end
+
+  private
+
+  def assert_method_defined(mod, method_name)
+    assert mod.method_defined?(method_name) || mod.private_method_defined?(method_name),
+      "Expected #{mod} to define #{method_name}"
+  end
+
+  def setup_git_repo(version)
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+    FileUtils.mkdir_p("lib/my_gem")
+    File.write("lib/my_gem/version.rb", "VERSION = \"#{version}\"")
+    File.write("CHANGELOG.md", <<~CHANGELOG)
+      # Changelog
+
+      ## [#{version}] - Unreleased
+
+      ### Added
+
+      - Initial release
+    CHANGELOG
+
+    system("git add .", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial commit'", out: File::NULL, err: File::NULL)
+    system("git branch -M main", out: File::NULL, err: File::NULL)
+  end
+end


### PR DESCRIPTION
## Summary

- Add `lib/hoe/reissue.rb` Hoe plugin that delegates to `Reissue::Task` and hooks into Hoe's `prerelease`/`postrelease` lifecycle
- Add tests verifying task creation, lifecycle hooks, defaults, and config pass-through to the `Reissue::Task` instance
- Document Hoe usage in README and `reissue:initialize` task output

## Test plan

- [x] `bundle exec rake test` passes (117 tests, 0 failures)
- [x] `bundle exec standardrb` passes on all changed files
- [ ] Manual: `Hoe.plugin :reissue` in a Hoe-based project shows tasks via `rake -T reissue`