### PR TITLE
Centralize changelog sections as Reissue.changelog_sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This hooks into Hoe's release lifecycle:
 - `prerelease` - Runs `reissue:bump` and `reissue:finalize` before release
 - `postrelease` - Runs `reissue` to bump version for the next development cycle
 
-All configuration options are available as `reissue_`-prefixed attributes (e.g., `reissue_version_file`, `reissue_changelog_file`). The version file defaults to `lib/#{name}/version.rb`.
+All configuration options are available as `reissue_`-prefixed attributes (e.g., `reissue_version_file`, `reissue_changelog_file`, `reissue_changelog_sections`). The version file defaults to `lib/#{name}/version.rb`.
 
 ### Non-Gem Projects
 
@@ -140,6 +140,11 @@ Reissue::Task.create :reissue do |task|
   # Note: Has no effect when using :git fragments
   task.clear_fragments = true
 
+  # Optional: Ordered list of valid changelog sections. Controls validation and display order.
+  # Defaults to: %w[Added Changed Deprecated Removed Fixed Security]
+  # Custom sections can be added; setting is idempotent (duplicates removed, names capitalized)
+  task.changelog_sections = %w[Major Added Changed Deprecated Removed Fixed Security]
+
   # Optional: Tag pattern for matching version tags. Defaults to /^v(\d+\.\d+\.\d+.*)$/
   # Must include a capture group for the version number.
   # Only applies when using :git fragments
@@ -193,13 +198,19 @@ Security: Rate limiting on login attempts"
 
 ### Supported Sections
 
-Git trailers use the standard Keep a Changelog sections:
+Git trailers use the standard [Keep a Changelog](http://keepachangelog.com/) sections by default:
 - `Added:` for new features
 - `Changed:` for changes in existing functionality
 - `Deprecated:` for soon-to-be removed features
 - `Removed:` for now removed features
 - `Fixed:` for any bug fixes
 - `Security:` for vulnerability fixes
+
+You can customize the valid sections with `changelog_sections`. This controls both which trailer names are recognized and the order sections appear in the changelog:
+
+```ruby
+task.changelog_sections = %w[Major Added Changed Deprecated Removed Fixed Security]
+```
 
 ### How It Works
 

--- a/lib/hoe/reissue.rb
+++ b/lib/hoe/reissue.rb
@@ -7,6 +7,7 @@ module Hoe::Reissue
     :reissue_version_limit, :reissue_version_redo_proc,
     :reissue_fragment, :reissue_clear_fragments,
     :reissue_retain_changelogs, :reissue_tag_pattern,
+    :reissue_changelog_sections,
     :reissue_commit, :reissue_commit_finalize,
     :reissue_push_finalize, :reissue_push_reissue,
     :reissue_updated_paths
@@ -20,6 +21,7 @@ module Hoe::Reissue
     self.reissue_clear_fragments = false
     self.reissue_retain_changelogs = false
     self.reissue_tag_pattern = nil
+    self.reissue_changelog_sections = nil
     self.reissue_commit = true
     self.reissue_commit_finalize = true
     self.reissue_push_finalize = false
@@ -37,6 +39,7 @@ module Hoe::Reissue
       clear_fragments: reissue_clear_fragments,
       retain_changelogs: reissue_retain_changelogs,
       tag_pattern: reissue_tag_pattern,
+      changelog_sections: reissue_changelog_sections,
       commit: reissue_commit,
       commit_finalize: reissue_commit_finalize,
       push_finalize: reissue_push_finalize,

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -7,6 +7,16 @@ require_relative "reissue/fragment_handler"
 
 # Reissue is a module that provides functionality for updating version numbers and changelogs.
 module Reissue
+  DEFAULT_CHANGELOG_SECTIONS = %w[Added Changed Deprecated Removed Fixed Security].freeze
+
+  def self.changelog_sections
+    @changelog_sections ||= DEFAULT_CHANGELOG_SECTIONS.dup
+  end
+
+  def self.changelog_sections=(sections)
+    @changelog_sections = Array(sections).map(&:capitalize).uniq
+  end
+
   # Updates the version number and changelog.
   #
   # @param version_file [String] The path to the version file.

--- a/lib/reissue/fragment_handler/directory_fragment_handler.rb
+++ b/lib/reissue/fragment_handler/directory_fragment_handler.rb
@@ -5,15 +5,13 @@ require "pathname"
 module Reissue
   # Handler for reading fragments from a directory
   class DirectoryFragmentHandler < FragmentHandler
-    DEFAULT_VALID_SECTIONS = %w[added changed deprecated removed fixed security].freeze
-
     attr_reader :directory, :valid_sections
 
     # Initialize the handler with a directory path
     #
     # @param directory [String] The path to the fragments directory
     # @param valid_sections [Array<String>, nil] List of valid section names, or nil to allow all
-    def initialize(directory, valid_sections: DEFAULT_VALID_SECTIONS)
+    def initialize(directory, valid_sections: Reissue.changelog_sections)
       @directory = directory
       @fragment_directory = Pathname.new(directory)
       @valid_sections = valid_sections

--- a/lib/reissue/fragment_handler/git_fragment_handler.rb
+++ b/lib/reissue/fragment_handler/git_fragment_handler.rb
@@ -4,12 +4,6 @@ module Reissue
   class FragmentHandler
     # Handles reading changelog entries from git commit trailers
     class GitFragmentHandler < FragmentHandler
-      # Valid changelog sections that can be used as trailers
-      VALID_SECTIONS = %w[Added Changed Deprecated Removed Fixed Security].freeze
-
-      # Regex to match changelog section trailers in commit messages
-      TRAILER_REGEX = /^(#{VALID_SECTIONS.join("|")}):\s*(.+)$/i
-
       # Default pattern for matching version tags (e.g., "v1.2.3")
       DEFAULT_TAG_PATTERN = /^v(\d+\.\d+\.\d+.*)$/
 
@@ -75,6 +69,10 @@ module Reissue
       end
 
       private
+
+      def trailer_regex
+        /^(#{Reissue.changelog_sections.join("|")}):\s*(.+)$/io
+      end
 
       def git_available?
         system("git --version", out: File::NULL, err: File::NULL)
@@ -161,7 +159,7 @@ module Reissue
             i += 1
             next if line.strip.empty?
 
-            if (match = line.match(TRAILER_REGEX))
+            if (match = line.match(trailer_regex))
               section_name = normalize_section_name(match[1])
               trailer_value = match[2].strip
 
@@ -170,7 +168,7 @@ module Reissue
                 next_line = lines[i].rstrip
                 # Stop at empty line or another changelog trailer
                 break if next_line.strip.empty?
-                break if next_line.match(TRAILER_REGEX)
+                break if next_line.match(trailer_regex)
 
                 trailer_value += " #{next_line.strip}"
                 i += 1

--- a/test/reissue/fragment_handler/git_fragment_handler_test.rb
+++ b/test/reissue/fragment_handler/git_fragment_handler_test.rb
@@ -16,6 +16,7 @@ module Reissue
 
       def teardown
         @handler = nil
+        Reissue.changelog_sections = Reissue::DEFAULT_CHANGELOG_SECTIONS
       end
 
       def test_initialization

--- a/test/test_changelog_sections.rb
+++ b/test/test_changelog_sections.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestChangelogSections < Minitest::Spec
+  after do
+    Reissue.changelog_sections = Reissue::DEFAULT_CHANGELOG_SECTIONS
+  end
+
+  describe "Reissue.changelog_sections" do
+    it "returns the default sections" do
+      assert_equal %w[Added Changed Deprecated Removed Fixed Security], Reissue.changelog_sections
+    end
+
+    it "returns a mutable copy of the default" do
+      sections = Reissue.changelog_sections
+      refute_same Reissue::DEFAULT_CHANGELOG_SECTIONS, sections
+    end
+
+    it "allows setting custom sections" do
+      Reissue.changelog_sections = %w[Major Added Changed]
+      assert_equal %w[Major Added Changed], Reissue.changelog_sections
+    end
+
+    it "capitalizes section names" do
+      Reissue.changelog_sections = %w[major added CHANGED]
+      assert_equal %w[Major Added Changed], Reissue.changelog_sections
+    end
+
+    it "removes duplicates" do
+      Reissue.changelog_sections = %w[Added added ADDED Changed]
+      assert_equal %w[Added Changed], Reissue.changelog_sections
+    end
+
+    it "is idempotent when prepending custom sections" do
+      Reissue.changelog_sections = %w[Major] + Reissue.changelog_sections
+      first_result = Reissue.changelog_sections.dup
+
+      Reissue.changelog_sections = %w[Major] + Reissue.changelog_sections
+      second_result = Reissue.changelog_sections
+
+      assert_equal first_result, second_result
+      assert_equal %w[Major Added Changed Deprecated Removed Fixed Security], first_result
+    end
+
+    it "wraps non-array values in an array" do
+      Reissue.changelog_sections = "custom"
+      assert_equal %w[Custom], Reissue.changelog_sections
+    end
+  end
+end

--- a/test/test_directory_fragment_handler.rb
+++ b/test/test_directory_fragment_handler.rb
@@ -7,6 +7,10 @@ require "reissue/fragment_handler"
 require "reissue/fragment_handler/directory_fragment_handler"
 
 class TestDirectoryFragmentHandler < Minitest::Spec
+  after do
+    Reissue.changelog_sections = Reissue::DEFAULT_CHANGELOG_SECTIONS
+  end
+
   describe "read" do
     before do
       @tmpdir = Dir.mktmpdir
@@ -138,7 +142,7 @@ class TestDirectoryFragmentHandler < Minitest::Spec
     end
 
     it "exposes valid_sections as attribute" do
-      assert_equal Reissue::DirectoryFragmentHandler::DEFAULT_VALID_SECTIONS, @handler.valid_sections
+      assert_equal Reissue::DEFAULT_CHANGELOG_SECTIONS, @handler.valid_sections
 
       custom_handler = Reissue::DirectoryFragmentHandler.new(@fragment_dir, valid_sections: %w[test])
       assert_equal %w[test], custom_handler.valid_sections
@@ -195,7 +199,7 @@ class TestDirectoryFragmentHandler < Minitest::Spec
     it "creates handler via factory with default sections" do
       handler = Reissue::FragmentHandler.for(@fragment_dir)
       assert_instance_of Reissue::DirectoryFragmentHandler, handler
-      assert_equal Reissue::DirectoryFragmentHandler::DEFAULT_VALID_SECTIONS, handler.valid_sections
+      assert_equal Reissue::DEFAULT_CHANGELOG_SECTIONS, handler.valid_sections
     end
 
     it "creates handler via factory with custom sections" do


### PR DESCRIPTION
## Summary

- Adds `Reissue.changelog_sections` accessor with a configurable, ordered section list (capitalize + uniq for idempotency)
- Replaces `DirectoryFragmentHandler::DEFAULT_VALID_SECTIONS` and `GitFragmentHandler::VALID_SECTIONS` with the centralized list
- Adds `changelog_sections` option to Rake task and Hoe plugin
- Documents the option in README and `reissue:initialize` help text

## Test plan

- [x] Full test suite passes (`bundle exec rake test` — 126 tests, 0 failures)
- [x] New tests for getter/setter: default value, custom values, capitalization, dedup, idempotency
- [x] Existing fragment handler tests updated and passing