### PR TITLE
Run bundle after reissue:bump updates the version

### DIFF
--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -379,6 +379,7 @@ module Reissue
           if bump
             updater = Reissue::VersionUpdater.new(version_file, version_redo_proc: version_redo_proc)
             updater.call(bump)
+            bundle
             puts "Version bumped (#{bump}) to #{updater.instance_variable_get(:@new_version)}"
           end
         elsif tag_version && current_version != tag_version
@@ -388,6 +389,7 @@ module Reissue
 
             if desired_version > current_version
               updater.call(bump)
+              bundle
               puts "Version bumped (#{bump}) to #{updater.instance_variable_get(:@new_version)}"
             else
               puts "Version already bumped (#{tag_version} → #{current_version}), skipping"
@@ -398,6 +400,7 @@ module Reissue
         elsif bump
           updater = Reissue::VersionUpdater.new(version_file, version_redo_proc: version_redo_proc)
           updater.call(bump)
+          bundle
           puts "Version bumped (#{bump}) to #{updater.instance_variable_get(:@new_version)}"
         end
       end


### PR DESCRIPTION
## Summary

- Calls `bundle` after `reissue:bump` updates the version file, matching the behavior of the main `reissue` task
- Adds 3 regression tests verifying bundle is called (or not) after bump

## Problem

When `reissue:bump` changes `version.rb` (e.g. from `2.1.14` to `3.0.0`), the `Gemfile.lock` becomes stale because it still references the old gemspec version. The subsequent `rake release` then fails at `release:guard_clean` because there are uncommitted changes to the lockfile.

This was hit in [SOFware/circulator's release workflow](https://github.com/SOFware/circulator/actions/runs/22360296819/job/64711527542):

```
Version bumped (major) to 3.0.0
circulator 2.1.14 built to pkg/circulator-3.0.0.gem.
There are files that need to be committed first.
Tasks: TOP => release => release:guard_clean
```

The main `reissue` task already calls `bundle` after updating the version — `reissue:bump` was missing the same call.

## Test plan

- [x] 3 new tests added:
  - `test_bump_calls_bundle_when_tag_matches_current_version` — standard bump path
  - `test_bump_calls_bundle_when_version_differs_from_tag` — post-release bump path (the exact failure scenario)
  - `test_bump_does_not_call_bundle_when_no_version_trailer` — no unnecessary calls
- [x] Full test suite passes (129 tests, 368 assertions)