### PR TITLE
Forward tag_pattern through call and finalize paths

### DIFF
--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -39,7 +39,8 @@ module Reissue
     version_limit: 2,
     version_redo_proc: nil,
     fragment: nil,
-    fragment_directory: nil
+    fragment_directory: nil,
+    tag_pattern: nil
   )
     # Handle deprecation
     if fragment_directory && !fragment
@@ -51,7 +52,7 @@ module Reissue
     new_version = version_updater.call(segment, version_file:)
     if changelog_file
       changelog_updater = ChangelogUpdater.new(changelog_file)
-      changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:, retain_changelogs:, fragment:)
+      changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:, retain_changelogs:, fragment:, tag_pattern:)
     end
     new_version
   end
@@ -64,7 +65,7 @@ module Reissue
   # @param fragment_directory [String] @deprecated Use fragment parameter instead
   #
   # @return [Array] The version number and release date.
-  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil)
+  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil)
     # Handle deprecation
     if fragment_directory && !fragment
       warn "[DEPRECATION] `fragment_directory` parameter is deprecated. Please use `fragment` instead."
@@ -90,7 +91,7 @@ module Reissue
         changelog_updater.write(changelog_file, retain_changelogs: false)
 
         # Get fragment changes
-        handler = FragmentHandler.for(fragment)
+        handler = FragmentHandler.for(fragment, tag_pattern:)
         fragment_changes = handler.read
 
         # Merge existing changes with fragment changes, deduplicating entries

--- a/lib/reissue/changelog_updater.rb
+++ b/lib/reissue/changelog_updater.rb
@@ -21,14 +21,14 @@ module Reissue
     # @param version_limit [Integer] The number of versions to keep (default: 2).
     # @param fragment [String] The fragment source configuration (default: nil).
     # @param fragment_directory [String] @deprecated Use fragment instead
-    def call(version, date: "Unreleased", changes: {}, changelog_file: @changelog_file, version_limit: 2, retain_changelogs: false, fragment: nil, fragment_directory: nil)
+    def call(version, date: "Unreleased", changes: {}, changelog_file: @changelog_file, version_limit: 2, retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil)
       # Handle deprecation
       if fragment_directory && !fragment
         warn "[DEPRECATION] `fragment_directory` parameter is deprecated. Please use `fragment` instead."
         fragment = fragment_directory
       end
 
-      update(version, date:, changes:, version_limit:, fragment:)
+      update(version, date:, changes:, version_limit:, fragment:, tag_pattern:)
       write(changelog_file, retain_changelogs:)
 
       changelog
@@ -57,13 +57,13 @@ module Reissue
     # @param version_limit [Integer] The number of versions to keep (default: 2).
     # @param fragment [String] The fragment source configuration (default: nil).
     # @return [Hash] The updated changelog.
-    def update(version, date: "Unreleased", changes: {}, version_limit: 2, fragment: nil)
+    def update(version, date: "Unreleased", changes: {}, version_limit: 2, fragment: nil, tag_pattern: nil)
       @changelog = Parser.parse(File.read(@changelog_file))
 
       # Merge fragment changes if source is provided
       merged_changes = changes.dup
       if fragment
-        handler = FragmentHandler.for(fragment)
+        handler = FragmentHandler.for(fragment, tag_pattern:)
         fragment_changes = handler.read
         fragment_changes.each do |section, entries|
           merged_changes[section] ||= []

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -201,7 +201,8 @@ module Reissue
           changelog_file:,
           version_limit:,
           version_redo_proc:,
-          fragment: fragment
+          fragment: fragment,
+          tag_pattern:
         )
         bundle
 
@@ -245,7 +246,8 @@ module Reissue
           date,
           changelog_file:,
           retain_changelogs:,
-          fragment: fragment
+          fragment: fragment,
+          tag_pattern:
         )
         finalize_message = "Finalize the changelog for version #{version} on #{date}"
         if commit_finalize


### PR DESCRIPTION
## Summary

- Thread `tag_pattern:` through `Reissue.call`, `Reissue.finalize`, `ChangelogUpdater#call`, and `ChangelogUpdater#update` so it reaches `FragmentHandler.for` in every code path
- The `reissue` (bump) and `reissue:finalize` rake tasks now forward `tag_pattern:` to the formatter
- Previously, `tag_pattern` was only forwarded in the `preview` and `bump` tasks, causing the git fragment handler to fall back to the default semver pattern in the main release workflow

**Root cause:** For projects using non-semver tags (e.g. `v2026.02.A`), the default pattern (`/^v(\d+\.\d+\.\d+.*)$/`) matched zero tags. This caused the handler to scan all commits in history and carry every historical trailer into the new version entry instead of starting clean.

## Test plan

- [x] Added tag_pattern forwarding tests to `test_changelog_updater.rb` (update and call)
- [x] Added tag_pattern forwarding tests to `test_reissue.rb` (Reissue.call and Reissue.finalize)
- [x] All 133 existing tests pass with no regressions