### PR TITLE
Thread tag_pattern through call and finalize chains

### DIFF
--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -39,7 +39,8 @@ module Reissue
     version_limit: 2,
     version_redo_proc: nil,
     fragment: nil,
-    fragment_directory: nil
+    fragment_directory: nil,
+    tag_pattern: nil
   )
     # Handle deprecation
     if fragment_directory && !fragment
@@ -51,7 +52,7 @@ module Reissue
     new_version = version_updater.call(segment, version_file:)
     if changelog_file
       changelog_updater = ChangelogUpdater.new(changelog_file)
-      changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:, retain_changelogs:, fragment:)
+      changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:, retain_changelogs:, fragment:, tag_pattern:)
     end
     new_version
   end
@@ -64,7 +65,7 @@ module Reissue
   # @param fragment_directory [String] @deprecated Use fragment parameter instead
   #
   # @return [Array] The version number and release date.
-  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil)
+  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil)
     # Handle deprecation
     if fragment_directory && !fragment
       warn "[DEPRECATION] `fragment_directory` parameter is deprecated. Please use `fragment` instead."
@@ -90,7 +91,7 @@ module Reissue
         changelog_updater.write(changelog_file, retain_changelogs: false)
 
         # Get fragment changes
-        handler = FragmentHandler.for(fragment)
+        handler = FragmentHandler.for(fragment, tag_pattern:)
         fragment_changes = handler.read
 
         # Merge existing changes with fragment changes, deduplicating entries

--- a/lib/reissue/changelog_updater.rb
+++ b/lib/reissue/changelog_updater.rb
@@ -21,14 +21,14 @@ module Reissue
     # @param version_limit [Integer] The number of versions to keep (default: 2).
     # @param fragment [String] The fragment source configuration (default: nil).
     # @param fragment_directory [String] @deprecated Use fragment instead
-    def call(version, date: "Unreleased", changes: {}, changelog_file: @changelog_file, version_limit: 2, retain_changelogs: false, fragment: nil, fragment_directory: nil)
+    def call(version, date: "Unreleased", changes: {}, changelog_file: @changelog_file, version_limit: 2, retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil)
       # Handle deprecation
       if fragment_directory && !fragment
         warn "[DEPRECATION] `fragment_directory` parameter is deprecated. Please use `fragment` instead."
         fragment = fragment_directory
       end
 
-      update(version, date:, changes:, version_limit:, fragment:)
+      update(version, date:, changes:, version_limit:, fragment:, tag_pattern:)
       write(changelog_file, retain_changelogs:)
 
       changelog
@@ -57,13 +57,13 @@ module Reissue
     # @param version_limit [Integer] The number of versions to keep (default: 2).
     # @param fragment [String] The fragment source configuration (default: nil).
     # @return [Hash] The updated changelog.
-    def update(version, date: "Unreleased", changes: {}, version_limit: 2, fragment: nil)
+    def update(version, date: "Unreleased", changes: {}, version_limit: 2, fragment: nil, tag_pattern: nil)
       @changelog = Parser.parse(File.read(@changelog_file))
 
       # Merge fragment changes if source is provided
       merged_changes = changes.dup
       if fragment
-        handler = FragmentHandler.for(fragment)
+        handler = FragmentHandler.for(fragment, tag_pattern:)
         fragment_changes = handler.read
         fragment_changes.each do |section, entries|
           merged_changes[section] ||= []

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -201,7 +201,9 @@ module Reissue
           changelog_file:,
           version_limit:,
           version_redo_proc:,
-          fragment: fragment
+          retain_changelogs:,
+          fragment: fragment,
+          tag_pattern:
         )
         bundle
 
@@ -245,7 +247,8 @@ module Reissue
           date,
           changelog_file:,
           retain_changelogs:,
-          fragment: fragment
+          fragment: fragment,
+          tag_pattern:
         )
         finalize_message = "Finalize the changelog for version #{version} on #{date}"
         if commit_finalize


### PR DESCRIPTION
## Summary

- `tag_pattern` configured on `Reissue::Task` was only forwarded to the `preview` and `bump` tasks, but not to the core `Reissue.call()` and `Reissue.finalize()` methods
- This caused `GitFragmentHandler` to always use its default pattern (`/^v(\d+\.\d+\.\d+.*)$/`), which fails for custom tag formats (e.g., `v2026.02.A`)
- Without matching tags, the handler reads ALL git trailers from the entire repo history, causing the new version to inherit all previous changelog entries
- Also forwards `retain_changelogs` to `formatter.call()` from the reissue rake task (was defaulting to `false`)

## Changes

Threads `tag_pattern:` through:
1. `rake.rb` — passes `tag_pattern:` and `retain_changelogs:` to `formatter.call()` and `formatter.finalize()`
2. `reissue.rb` — accepts `tag_pattern:` in `call()` and `finalize()`, forwards to `FragmentHandler.for()`
3. `changelog_updater.rb` — accepts `tag_pattern:` in `call()` and `update()`, forwards to `FragmentHandler.for()`

## Test plan

- [x] All 129 existing tests pass
- [ ] Verify with a project using custom `tag_pattern` that `reissue:finalize` and `reissue` correctly scope git trailers to commits since the last matching tag