### PR TITLE
Track RELEASE_DATE constant in version file

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ Reissue::Task.create :reissue do |task|
 end
 ```
 
+## Tracking Release Dates
+
+Reissue can automatically manage a `RELEASE_DATE` constant in your version file alongside `VERSION`. This is completely optional — if no `RELEASE_DATE` is present, nothing changes.
+
+### Opting In
+
+Add a `RELEASE_DATE` constant to your version file:
+
+```ruby
+module MyGem
+  VERSION = "0.1.0"
+  RELEASE_DATE = "Unreleased"
+end
+```
+
+### What Happens Automatically
+
+- **On finalize** (`rake build` / `rake reissue:finalize`): `RELEASE_DATE` is set to the actual release date (e.g., `"2024-06-15"`)
+- **On bump** (`rake reissue` / post-release): `RELEASE_DATE` is reset to `"Unreleased"`
+
+No configuration is needed — Reissue detects the constant and updates it automatically.
+
 ## Using Git Trailers for Changelog Entries
 
 Reissue can extract changelog entries directly from git commit messages using trailers. This keeps your changelog data close to the code changes.

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -50,6 +50,7 @@ module Reissue
 
     version_updater = VersionUpdater.new(version_file, version_redo_proc:)
     new_version = version_updater.call(segment, version_file:)
+    version_updater.update_release_date("Unreleased", version_file:)
     if changelog_file
       changelog_updater = ChangelogUpdater.new(changelog_file)
       changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:, retain_changelogs:, fragment:, tag_pattern:)

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -66,7 +66,7 @@ module Reissue
   # @param fragment_directory [String] @deprecated Use fragment parameter instead
   #
   # @return [Array] The version number and release date.
-  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil)
+  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil, version_file: nil)
     # Handle deprecation
     if fragment_directory && !fragment
       warn "[DEPRECATION] `fragment_directory` parameter is deprecated. Please use `fragment` instead."
@@ -119,6 +119,11 @@ module Reissue
 
     # Now finalize with the date
     changelog = changelog_updater.finalize(date:, changelog_file:, retain_changelogs:)
+
+    if version_file
+      version_updater = VersionUpdater.new(version_file)
+      version_updater.update_release_date(date.to_s, version_file:)
+    end
 
     changelog["versions"].first.slice("version", "date").values
   end

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -247,7 +247,8 @@ module Reissue
           changelog_file:,
           retain_changelogs:,
           fragment: fragment,
-          tag_pattern:
+          tag_pattern:,
+          version_file:
         )
         finalize_message = "Finalize the changelog for version #{version} on #{date}"
         if commit_finalize

--- a/lib/reissue/version_updater.rb
+++ b/lib/reissue/version_updater.rb
@@ -108,6 +108,19 @@ module Reissue
     VERSION_MATCH = /(?<major>\d+)\.(?<minor>[a-zA-Z\d]+)\.(?<patch>[a-zA-Z\d]+)(?<add>\.(?<pre>[a-zA-Z\d]+))?/
     def version_regex = VERSION_MATCH
 
+    RELEASE_DATE_MATCH = /RELEASE_DATE\s*=\s*"([^"]*)"/
+
+    def release_date_regex = RELEASE_DATE_MATCH
+
+    def update_release_date(date, version_file: @version_file)
+      body = File.read(@version_file)
+      return unless body.match?(release_date_regex)
+      updated = body.gsub(release_date_regex) do |match|
+        match.sub(/=\s*"[^"]*"/, "= \"#{date}\"")
+      end
+      File.write(version_file, updated)
+    end
+
     # Writes the updated version to the specified file.
     #
     # @param version_file [String] The version_file to the version file (optional, defaults to @version_file).

--- a/test/fixtures/version_with_release_date.rb
+++ b/test/fixtures/version_with_release_date.rb
@@ -1,0 +1,6 @@
+module Reissue
+  module FakeGem
+    VERSION = "0.1.0"
+    RELEASE_DATE = "Unreleased"
+  end
+end

--- a/test/test_reissue.rb
+++ b/test/test_reissue.rb
@@ -309,6 +309,31 @@ class TestReissue < Minitest::Spec
         end
       end
     end
+
+    it "updates RELEASE_DATE in version file on finalize" do
+      fixture_changelog = File.expand_path("fixtures/changelog.md", __dir__)
+      changelog_file = Tempfile.new
+      changelog_file << File.read(fixture_changelog)
+      changelog_file.close
+
+      version_file = Tempfile.new
+      version_file << "module MyGem\n  VERSION = \"0.1.2\"\n  RELEASE_DATE = \"Unreleased\"\nend\n"
+      version_file.close
+
+      Reissue.finalize("2026-02-24", changelog_file: changelog_file.path, version_file: version_file.path)
+
+      contents = File.read(version_file)
+      assert_match(/RELEASE_DATE = "2026-02-24"/, contents)
+    end
+
+    it "does not fail when version_file is not provided to finalize" do
+      fixture_changelog = File.expand_path("fixtures/changelog.md", __dir__)
+      changelog_file = Tempfile.new
+      changelog_file << File.read(fixture_changelog)
+      changelog_file.close
+
+      Reissue.finalize("2026-02-24", changelog_file: changelog_file.path)
+    end
   end
 
   describe ".reformat" do

--- a/test/test_reissue.rb
+++ b/test/test_reissue.rb
@@ -118,6 +118,28 @@ class TestReissue < Minitest::Spec
         end
       end
     end
+    it "resets RELEASE_DATE to Unreleased when bumping version" do
+      version_file = Tempfile.new
+      version_file << "module MyGem\n  VERSION = \"0.1.0\"\n  RELEASE_DATE = \"2026-02-24\"\nend\n"
+      version_file.close
+
+      Reissue.call(version_file:, segment: "patch", changelog_file: nil)
+
+      contents = File.read(version_file)
+      assert_match(/RELEASE_DATE = "Unreleased"/, contents)
+    end
+
+    it "does not fail when RELEASE_DATE is absent during bump" do
+      fixture = File.expand_path("fixtures/version.rb", __dir__)
+      version_file = Tempfile.new
+      version_file << File.read(fixture)
+      version_file.close
+
+      Reissue.call(version_file:, segment: "major", changelog_file: nil)
+
+      contents = File.read(version_file)
+      refute_match(/RELEASE_DATE/, contents)
+    end
   end
 
   describe ".finalize" do

--- a/test/test_version_updater.rb
+++ b/test/test_version_updater.rb
@@ -83,4 +83,38 @@ class TestVersionUpdater < Minitest::Spec
       end
     end
   end
+
+  describe "update_release_date" do
+    it "updates RELEASE_DATE in the version file" do
+      file = File.expand_path("fixtures/version_with_release_date.rb", __dir__)
+      tempfile = Tempfile.new
+      updater = Reissue::VersionUpdater.new(file)
+
+      updater.update_release_date("2026-02-24", version_file: tempfile.path)
+      contents = File.read(tempfile.path)
+      assert_match(/RELEASE_DATE = "2026-02-24"/, contents)
+    end
+
+    it "does nothing when RELEASE_DATE is not present" do
+      file = File.expand_path("fixtures/version.rb", __dir__)
+      tempfile = Tempfile.new
+      updater = Reissue::VersionUpdater.new(file)
+
+      updater.update_release_date("2026-02-24", version_file: tempfile.path)
+      contents = File.read(tempfile.path)
+      refute_match(/RELEASE_DATE/, contents)
+    end
+
+    it "preserves existing RELEASE_DATE format with empty string" do
+      file = File.expand_path("fixtures/version_with_release_date.rb", __dir__)
+      tempfile = Tempfile.new
+      tempfile << File.read(file).sub('RELEASE_DATE = "Unreleased"', 'RELEASE_DATE = ""')
+      tempfile.close
+      updater = Reissue::VersionUpdater.new(tempfile.path)
+
+      updater.update_release_date("2026-02-24", version_file: tempfile.path)
+      contents = File.read(tempfile.path)
+      assert_match(/RELEASE_DATE = "2026-02-24"/, contents)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add `update_release_date` method to `VersionUpdater` using regex-based gsub (no-ops when constant is absent)
- Reset `RELEASE_DATE` to `"Unreleased"` on version bump via `Reissue.call`
- Set `RELEASE_DATE` to the actual date on `Reissue.finalize` when `version_file:` is provided
- Forward `version_file:` through the finalize rake task

## Test Plan

- [x] Unit tests for `update_release_date` (updates value, no-ops when absent, handles empty string)
- [x] Integration tests for `Reissue.call` (resets to Unreleased, safe without constant)
- [x] Integration tests for `Reissue.finalize` (sets date, safe without version_file)
- [x] Full suite passes (140 runs, 394 assertions, 0 failures)
- [x] standardrb clean