### PR TITLE
Add deferred versioning mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 /.claude/settings.local.json
+.worktrees/

--- a/lib/hoe/reissue.rb
+++ b/lib/hoe/reissue.rb
@@ -10,7 +10,7 @@ module Hoe::Reissue
     :reissue_changelog_sections,
     :reissue_commit, :reissue_commit_finalize,
     :reissue_push_finalize, :reissue_push_reissue,
-    :reissue_updated_paths
+    :reissue_updated_paths, :reissue_deferred_versioning
 
   def initialize_reissue
     self.reissue_version_file = "lib/#{name}/version.rb"
@@ -27,6 +27,7 @@ module Hoe::Reissue
     self.reissue_push_finalize = false
     self.reissue_push_reissue = :branch
     self.reissue_updated_paths = []
+    self.reissue_deferred_versioning = false
   end
 
   def define_reissue_tasks
@@ -44,7 +45,8 @@ module Hoe::Reissue
       commit_finalize: reissue_commit_finalize,
       push_finalize: reissue_push_finalize,
       push_reissue: reissue_push_reissue,
-      updated_paths: reissue_updated_paths
+      updated_paths: reissue_updated_paths,
+      deferred_versioning: reissue_deferred_versioning
     }
 
     Reissue::Task.create :reissue do

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -58,6 +58,19 @@ module Reissue
     new_version
   end
 
+  def self.deferred_call(version_file:, changelog_file: "CHANGELOG.md", version_limit: 2, retain_changelogs: false, fragment: nil, tag_pattern: nil)
+    version_updater = VersionUpdater.new(version_file)
+    version_updater.set_version("Unreleased", version_file:)
+    version_updater.update_release_date("Unreleased", version_file:)
+
+    if changelog_file
+      changelog_updater = ChangelogUpdater.new(changelog_file)
+      changelog_updater.call("Unreleased", date: nil, changes: {}, changelog_file:, version_limit:, retain_changelogs:, fragment:, tag_pattern:)
+    end
+
+    "Unreleased"
+  end
+
   # Finalizes the changelog for an unreleased version to set the release date.
   #
   # @param date [String] The release date.

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -71,6 +71,88 @@ module Reissue
     "Unreleased"
   end
 
+  def self.deferred_finalize(date = Date.today, version: nil, segment: nil, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, tag_pattern: nil, version_file: nil, version_redo_proc: nil)
+    resolved_version = if version&.match?(/^\d/)
+      version
+    elsif segment || version
+      seg = segment || version
+      resolved = resolve_version_from_tag(seg.to_s, tag_pattern: tag_pattern, version_redo_proc: version_redo_proc)
+      unless resolved
+        raise "Cannot determine next version. No git tags found and no explicit version provided. " \
+              "Usage: rake reissue:finalize[patch] or rake reissue:finalize[1.2.0]"
+      end
+      resolved
+    elsif fragment == :git
+      handler = FragmentHandler.for(:git, tag_pattern: tag_pattern)
+      bump = handler.read_version_bump
+      if bump
+        resolved = resolve_version_from_tag(bump.to_s, tag_pattern: tag_pattern, version_redo_proc: version_redo_proc)
+        unless resolved
+          raise "Cannot determine next version. No git tags found and no explicit version provided. " \
+                "Usage: rake reissue:finalize[patch] or rake reissue:finalize[1.2.0]"
+        end
+        resolved
+      else
+        raise "Cannot determine next version. No git tags found and no version argument provided. " \
+              "Usage: rake reissue:finalize[patch] or rake reissue:finalize[1.2.0]"
+      end
+    else
+      raise "Cannot determine next version. No version argument provided. " \
+            "Usage: rake reissue:finalize[patch] or rake reissue:finalize[1.2.0]"
+    end
+
+    if version_file
+      version_updater = VersionUpdater.new(version_file)
+      version_updater.set_version(resolved_version, version_file: version_file)
+      version_updater.update_release_date(date.to_s, version_file: version_file)
+    end
+
+    changelog_updater = ChangelogUpdater.new(changelog_file)
+
+    if fragment
+      changelog = Parser.parse(File.read(changelog_file))
+      unreleased = changelog["versions"].find { |v| v["version"] == "Unreleased" }
+
+      if unreleased
+        changelog["versions"].delete(unreleased)
+        changelog_updater.instance_variable_set(:@changelog, changelog)
+        changelog_updater.write(changelog_file, retain_changelogs: false)
+
+        handler = FragmentHandler.for(fragment, tag_pattern: tag_pattern)
+        fragment_changes = handler.read
+
+        merged_changes = (unreleased["changes"] || {}).dup
+        fragment_changes.each do |section, entries|
+          merged_changes[section] ||= []
+          entries.each do |entry|
+            merged_changes[section] << entry unless merged_changes[section].include?(entry)
+          end
+        end
+
+        changelog_updater.update(
+          "Unreleased",
+          date: nil,
+          changes: merged_changes,
+          fragment: nil,
+          version_limit: changelog["versions"].size + 1
+        )
+        changelog_updater.write(changelog_file, retain_changelogs: false)
+      end
+    end
+
+    changelog = changelog_updater.finalize(date: date, changelog_file: changelog_file, retain_changelogs: retain_changelogs, resolved_version: resolved_version)
+    changelog["versions"].first.slice("version", "date").values
+  end
+
+  private_class_method def self.resolve_version_from_tag(segment, tag_pattern: nil, version_redo_proc: nil)
+    handler = FragmentHandler.for(:git, tag_pattern: tag_pattern)
+    last_version = handler.last_tag_version
+    return nil unless last_version
+
+    updater = VersionUpdater.new(File::NULL, version_redo_proc: version_redo_proc)
+    updater.redo(last_version, segment).to_s
+  end
+
   # Finalizes the changelog for an unreleased version to set the release date.
   #
   # @param date [String] The release date.

--- a/lib/reissue/changelog_updater.rb
+++ b/lib/reissue/changelog_updater.rb
@@ -34,12 +34,19 @@ module Reissue
       changelog
     end
 
-    def finalize(date: Date.today, changelog_file: @changelog_file, retain_changelogs: false)
+    def finalize(date: Date.today, changelog_file: @changelog_file, retain_changelogs: false, resolved_version: nil)
       @changelog = Parser.parse(File.read(changelog_file))
 
       # find the highest version number and if it is unreleased, update the date
       version = latest_version
+      version_value = version["version"]
       version_date = version["date"]
+
+      # In deferred mode, resolved_version replaces "Unreleased" version string
+      if resolved_version && version_value == "Unreleased"
+        version["version"] = resolved_version
+      end
+
       if version_date.nil? || version_date == "Unreleased"
         changelog["versions"].find do |v|
           v["version"] == version["version"]
@@ -124,7 +131,9 @@ module Reissue
     private
 
     def latest_version
-      changelog["versions"].max_by { |v| ::Gem::Version.new(v["version"]) }
+      versioned, unversioned = changelog["versions"].partition { |v| v["version"] != "Unreleased" }
+      return unversioned.first if unversioned.any?
+      versioned.max_by { |v| ::Gem::Version.new(v["version"]) }
     end
   end
 end

--- a/lib/reissue/markdown.rb
+++ b/lib/reissue/markdown.rb
@@ -63,9 +63,13 @@ module Reissue
         return unless @version.nil? && @date.nil? && @changes.empty?
         # the first line contains the version and date
         scanner = StringScanner.new(@chunk) << "\n"
-        scanner.scan(/\[?(.[^\]]+)\]? - (.+)$/)
-        @version = scanner[1].to_s.strip
-        @date = scanner[2].to_s.strip || "Unreleased"
+        if scanner.scan(/\[?(.[^\]]+)\]? - (.+)$/)
+          @version = scanner[1].to_s.strip
+          @date = scanner[2].to_s.strip
+        elsif scanner.scan(/\[?([^\]\s]+)\]?\s*$/)
+          @version = scanner[1].to_s.strip
+          @date = nil
+        end
 
         # the rest of the text is the changes
         @changes = scanner.rest.strip.split("### ").reject(&:empty?).map { |change| Change.new(change) }

--- a/lib/reissue/printer.rb
+++ b/lib/reissue/printer.rb
@@ -24,7 +24,11 @@ module Reissue
         changes = data.fetch("changes") do
           {}
         end
-        version_string = "## [#{version}] - #{date}"
+        version_string = if version == "Unreleased" && date.nil?
+          "## [Unreleased]"
+        else
+          "## [#{version}] - #{date}"
+        end
         changes_string = changes.map do |section, section_changes|
           format_section(section, section_changes)
         end.join("\n\n")

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -107,6 +107,11 @@ module Reissue
     # Default: nil (uses default pattern matching "v1.2.3")
     attr_accessor :tag_pattern
 
+    # Whether to defer version bumping until finalize time. Default: false.
+    # When true, the reissue task sets VERSION to "Unreleased" instead of bumping,
+    # and the finalize task resolves the version from git tags + segment argument.
+    attr_accessor :deferred_versioning
+
     # The ordered list of valid changelog sections.
     # Controls both validation (which sections are accepted) and ordering (how they appear).
     # Default: nil (uses Reissue.changelog_sections)
@@ -132,6 +137,7 @@ module Reissue
       @push_reissue = :branch
       @tag_pattern = nil
       @changelog_sections = nil
+      @deferred_versioning = false
     end
 
     attr_reader :formatter, :tasker
@@ -194,16 +200,26 @@ module Reissue
 
       desc description
       task name, [:segment] do |task, args|
-        segment = args[:segment] || "patch"
-        new_version = formatter.call(
-          segment:,
-          version_file:,
-          changelog_file:,
-          version_limit:,
-          version_redo_proc:,
-          fragment: fragment,
-          tag_pattern:
-        )
+        if deferred_versioning
+          new_version = formatter.deferred_call(
+            version_file:,
+            changelog_file:,
+            version_limit:,
+            fragment: fragment,
+            tag_pattern:
+          )
+        else
+          segment = args[:segment] || "patch"
+          new_version = formatter.call(
+            segment:,
+            version_file:,
+            changelog_file:,
+            version_limit:,
+            version_redo_proc:,
+            fragment: fragment,
+            tag_pattern:
+          )
+        end
         bundle
 
         tasker["#{name}:clear_fragments"].invoke
@@ -211,11 +227,20 @@ module Reissue
         run_command("git add -u", "Failed to stage updated files")
         stage_updated_paths
 
-        bump_message = "Bump version to #{new_version}"
+        bump_message = if deferred_versioning
+          "Prepare for next development version"
+        else
+          "Bump version to #{new_version}"
+        end
         if commit
           if reissue_version_with_branch?
             tasker["#{name}:branch"].reenable
-            tasker["#{name}:branch"].invoke("reissue/#{new_version}")
+            branch_name = if deferred_versioning
+              "reissue/next"
+            else
+              "reissue/#{new_version}"
+            end
+            tasker["#{name}:branch"].invoke(branch_name)
           end
           run_command("git commit -m '#{bump_message}'", "Failed to commit version bump")
           tasker["#{name}:push"].invoke if push_reissue?
@@ -240,20 +265,45 @@ module Reissue
       end
 
       desc "Finalize the changelog for an unreleased version to set the release date."
-      task "#{name}:finalize", [:date] do |task, args|
-        date = args[:date] || Time.now.strftime("%Y-%m-%d")
-        version, date = formatter.finalize(
-          date,
-          changelog_file:,
-          retain_changelogs:,
-          fragment: fragment,
-          tag_pattern:,
-          version_file:
-        )
+      task "#{name}:finalize", [:version_or_segment, :date] do |task, args|
+        if deferred_versioning
+          version_or_segment = args[:version_or_segment]
+          date = args[:date] || Time.now.strftime("%Y-%m-%d")
+
+          version_arg = nil
+          segment_arg = nil
+          if version_or_segment&.match?(/^\d/)
+            version_arg = version_or_segment
+          elsif version_or_segment
+            segment_arg = version_or_segment
+          end
+
+          version, date = formatter.deferred_finalize(
+            date,
+            version: version_arg,
+            segment: segment_arg,
+            changelog_file:,
+            retain_changelogs:,
+            fragment: fragment,
+            tag_pattern:,
+            version_file:,
+            version_redo_proc:
+          )
+        else
+          date = args[:version_or_segment] || Time.now.strftime("%Y-%m-%d")
+          version, date = formatter.finalize(
+            date,
+            changelog_file:,
+            retain_changelogs:,
+            fragment: fragment,
+            tag_pattern:,
+            version_file:
+          )
+        end
+
         finalize_message = "Finalize the changelog for version #{version} on #{date}"
         if commit_finalize
           if finalize_with_branch?
-            # Use "finalize/" prefix for the version being released
             tasker["#{name}:branch"].invoke("finalize/#{version}")
           end
           run_command("git add -u", "Failed to stage finalized changelog")
@@ -361,6 +411,7 @@ module Reissue
 
       desc "Bump version based on git trailers"
       task "#{name}:bump" do
+        next if deferred_versioning
         # Only check for version trailers when using git fragments
         next unless fragment == :git
 

--- a/lib/reissue/version_updater.rb
+++ b/lib/reissue/version_updater.rb
@@ -77,11 +77,11 @@ module Reissue
       @new_version
     end
 
-    VERSION_STRING_MATCH = /VERSION\s*=\s*"[^"]*"/
-
     def set_version(version_string, version_file: @version_file)
       body = File.read(@version_file)
-      updated = body.gsub(VERSION_STRING_MATCH, "VERSION = \"#{version_string}\"")
+      updated = body.gsub(release_version_regex) do |match|
+        match.sub(/=\s*"[^"]*"/, "= \"#{version_string}\"")
+      end
       File.write(version_file, updated)
       version_string
     end
@@ -117,8 +117,10 @@ module Reissue
     VERSION_MATCH = /(?<major>\d+)\.(?<minor>[a-zA-Z\d]+)\.(?<patch>[a-zA-Z\d]+)(?<add>\.(?<pre>[a-zA-Z\d]+))?/
     def version_regex = VERSION_MATCH
 
+    RELEASE_VERSION_MATCH = /VERSION\s*=\s*"([^"]*)"/
     RELEASE_DATE_MATCH = /RELEASE_DATE\s*=\s*"([^"]*)"/
 
+    def release_version_regex = RELEASE_VERSION_MATCH
     def release_date_regex = RELEASE_DATE_MATCH
 
     def update_release_date(date, version_file: @version_file)

--- a/lib/reissue/version_updater.rb
+++ b/lib/reissue/version_updater.rb
@@ -77,6 +77,15 @@ module Reissue
       @new_version
     end
 
+    VERSION_STRING_MATCH = /VERSION\s*=\s*"[^"]*"/
+
+    def set_version(version_string, version_file: @version_file)
+      body = File.read(@version_file)
+      updated = body.gsub(VERSION_STRING_MATCH, "VERSION = \"#{version_string}\"")
+      File.write(version_file, updated)
+      version_string
+    end
+
     # A proc that can be used to redo the version string.
     attr_accessor :version_redo_proc
 

--- a/test/test_changelog_updater.rb
+++ b/test/test_changelog_updater.rb
@@ -45,6 +45,66 @@ class TestChangelogUpdater < Minitest::Spec
       contents = @changelog_updater.to_s
       assert_match(/\[1.0\.0\]/, contents)
     end
+
+    it "handles Unreleased as a version string" do
+      changelog_content = <<~MD
+        # Changelog
+
+        All notable changes.
+
+        ## [Unreleased]
+
+        ### Added
+
+        - Work in progress
+
+        ## [1.0.0] - 2026-01-01
+
+        ### Added
+
+        - Initial release
+      MD
+      tempfile = Tempfile.new
+      File.write(tempfile.path, changelog_content)
+      updater = Reissue::ChangelogUpdater.new(tempfile.path)
+
+      updater.finalize(date: "2026-03-06", changelog_file: tempfile.path)
+
+      contents = File.read(tempfile.path)
+      # Without resolved_version, Unreleased stays as version but gets no date suffix issue
+      # The key test is that it doesn't raise an error
+      refute_match(/## \[Unreleased\] - Unreleased/, contents)
+    end
+
+    it "replaces Unreleased version with resolved version on finalize" do
+      changelog_content = <<~MD
+        # Changelog
+
+        All notable changes.
+
+        ## [Unreleased]
+
+        ### Added
+
+        - Work in progress
+
+        ## [1.0.0] - 2026-01-01
+
+        ### Added
+
+        - Initial release
+      MD
+      tempfile = Tempfile.new
+      File.write(tempfile.path, changelog_content)
+      updater = Reissue::ChangelogUpdater.new(tempfile.path)
+
+      updater.finalize(date: "2026-03-06", changelog_file: tempfile.path, resolved_version: "1.1.0")
+
+      contents = File.read(tempfile.path)
+      assert_match(/\[1.1.0\] - 2026-03-06/, contents)
+      refute_match(/Unreleased/, contents)
+      assert_match(/Work in progress/, contents)
+    end
   end
 
   describe "update" do

--- a/test/test_deferred_versioning_integration.rb
+++ b/test/test_deferred_versioning_integration.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+
+class TestDeferredVersioningIntegration < Minitest::Spec
+  before do
+    @original_dir = Dir.pwd
+    @tmpdir = Dir.mktmpdir
+    Dir.chdir(@tmpdir)
+
+    system("git init -q && git config user.name 'Test' && git config user.email 'test@test.com'", out: File::NULL, err: File::NULL)
+
+    FileUtils.mkdir_p("lib/myapp")
+    File.write("lib/myapp/version.rb", <<~RUBY)
+      module MyApp
+        VERSION = "1.0.0"
+        RELEASE_DATE = "2026-03-01"
+      end
+    RUBY
+
+    File.write("CHANGELOG.md", <<~MD)
+      # Changelog
+
+      All notable changes.
+
+      ## [1.0.0] - 2026-03-01
+
+      ### Added
+
+      - Initial release
+    MD
+
+    system("git add . && git commit -q -m 'Release 1.0.0'", out: File::NULL, err: File::NULL)
+    system("git tag v1.0.0")
+  end
+
+  after do
+    Dir.chdir(@original_dir)
+    FileUtils.remove_entry @tmpdir
+  end
+
+  describe "full deferred workflow" do
+    it "post-release sets Unreleased, finalize resolves version from segment" do
+      # Step 1: Post-release (deferred)
+      Reissue.deferred_call(
+        version_file: "lib/myapp/version.rb",
+        changelog_file: "CHANGELOG.md",
+        version_limit: 5
+      )
+
+      # Verify post-release state
+      version_contents = File.read("lib/myapp/version.rb")
+      assert_match(/VERSION = "Unreleased"/, version_contents)
+      assert_match(/RELEASE_DATE = "Unreleased"/, version_contents)
+
+      changelog_contents = File.read("CHANGELOG.md")
+      assert_match(/## \[Unreleased\]\n/, changelog_contents)
+      assert_match(/## \[1.0.0\] - 2026-03-01/, changelog_contents)
+
+      # Step 2: Finalize with segment
+      version, date = Reissue.deferred_finalize(
+        "2026-03-06",
+        segment: "minor",
+        changelog_file: "CHANGELOG.md",
+        version_file: "lib/myapp/version.rb"
+      )
+
+      assert_equal "1.1.0", version
+      assert_equal "2026-03-06", date
+
+      # Verify final state
+      version_contents = File.read("lib/myapp/version.rb")
+      assert_match(/VERSION = "1.1.0"/, version_contents)
+      assert_match(/RELEASE_DATE = "2026-03-06"/, version_contents)
+
+      changelog_contents = File.read("CHANGELOG.md")
+      assert_match(/\[1.1.0\] - 2026-03-06/, changelog_contents)
+      refute_match(/Unreleased/, changelog_contents)
+    end
+
+    it "finalize resolves version from explicit version string" do
+      Reissue.deferred_call(
+        version_file: "lib/myapp/version.rb",
+        changelog_file: "CHANGELOG.md",
+        version_limit: 5
+      )
+
+      version, _ = Reissue.deferred_finalize(
+        "2026-03-06",
+        version: "2.0.0",
+        changelog_file: "CHANGELOG.md",
+        version_file: "lib/myapp/version.rb"
+      )
+
+      assert_equal "2.0.0", version
+
+      version_contents = File.read("lib/myapp/version.rb")
+      assert_match(/VERSION = "2.0.0"/, version_contents)
+
+      changelog_contents = File.read("CHANGELOG.md")
+      assert_match(/\[2.0.0\] - 2026-03-06/, changelog_contents)
+      refute_match(/Unreleased/, changelog_contents)
+    end
+
+    it "finalize resolves version from git trailers when using git fragments" do
+      Reissue.deferred_call(
+        version_file: "lib/myapp/version.rb",
+        changelog_file: "CHANGELOG.md",
+        version_limit: 5
+      )
+
+      system("git add . && git commit -q -m 'Prepare for development'", out: File::NULL, err: File::NULL)
+
+      # Simulate development commits with trailers
+      File.write("feature.rb", "# new feature")
+      system("git add .", out: File::NULL, err: File::NULL)
+      Tempfile.create("commit_msg") do |f|
+        f.write("Add new feature\n\nAdded: Cool new feature\nVersion: minor")
+        f.flush
+        system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
+      end
+
+      version, _ = Reissue.deferred_finalize(
+        "2026-03-06",
+        changelog_file: "CHANGELOG.md",
+        version_file: "lib/myapp/version.rb",
+        fragment: :git
+      )
+
+      assert_equal "1.1.0", version
+
+      changelog_contents = File.read("CHANGELOG.md")
+      assert_match(/Cool new feature/, changelog_contents)
+      assert_match(/\[1.1.0\] - 2026-03-06/, changelog_contents)
+    end
+
+    it "preserves existing changelog entries through the deferred workflow" do
+      # Post-release with some manual changelog entries
+      Reissue.deferred_call(
+        version_file: "lib/myapp/version.rb",
+        changelog_file: "CHANGELOG.md",
+        version_limit: 5
+      )
+
+      # Manually add entries to the Unreleased section
+      changelog = File.read("CHANGELOG.md")
+      changelog.sub!("## [Unreleased]", "## [Unreleased]\n\n### Added\n\n- Manual feature\n- Another feature")
+      File.write("CHANGELOG.md", changelog)
+
+      # Finalize
+      _, _ = Reissue.deferred_finalize(
+        "2026-03-06",
+        version: "1.1.0",
+        changelog_file: "CHANGELOG.md",
+        version_file: "lib/myapp/version.rb"
+      )
+
+      changelog_contents = File.read("CHANGELOG.md")
+      assert_match(/Manual feature/, changelog_contents)
+      assert_match(/Another feature/, changelog_contents)
+      assert_match(/\[1.1.0\] - 2026-03-06/, changelog_contents)
+    end
+  end
+end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -55,6 +55,34 @@ class TestParser < Minitest::Spec
       )
     end
 
+    it "parses a changelog with an Unreleased version (no date)" do
+      changelog = <<~MD
+        # Changelog
+
+        All notable changes.
+
+        ## [Unreleased]
+
+        ### Added
+
+        - New feature in progress
+
+        ## [1.0.0] - 2026-01-01
+
+        ### Added
+
+        - Initial release
+      MD
+
+      changes = Reissue::Parser.parse(changelog)
+
+      assert_equal "Unreleased", changes.dig("versions", 0, "version")
+      assert_nil changes.dig("versions", 0, "date")
+      assert_equal ["New feature in progress"], changes.dig("versions", 0, "changes", "Added")
+      assert_equal "1.0.0", changes.dig("versions", 1, "version")
+      assert_equal "2026-01-01", changes.dig("versions", 1, "date")
+    end
+
     it "handles files without an empty last line" do
       changelog = File.read("test/fixtures/changelog.md").chomp
 

--- a/test/test_printer.rb
+++ b/test/test_printer.rb
@@ -52,6 +52,30 @@ class TestPrinter < Minitest::Spec
       MARKDOWN
     end
 
+    it "prints Unreleased version without date suffix" do
+      changelog = {
+        "title" => "Changelog",
+        "preamble" => "This is a changelog.",
+        "versions" => [
+          {
+            "version" => "Unreleased",
+            "date" => nil
+          },
+          {
+            "version" => "1.0.0",
+            "date" => "2021-01-01",
+            "changes" => {
+              "Added" => ["New feature"]
+            }
+          }
+        ]
+      }
+      printer = Reissue::Printer.new(changelog)
+      result = printer.to_s
+      assert_match(/## \[Unreleased\]\n/, result)
+      refute_match(/## \[Unreleased\] -/, result)
+    end
+
     it "handles nil versions" do
       changelog = {}
       printer = Reissue::Printer.new(changelog)

--- a/test/test_reissue.rb
+++ b/test/test_reissue.rb
@@ -496,6 +496,126 @@ class TestReissue < Minitest::Spec
     end
   end
 
+  describe ".deferred_finalize" do
+    it "resolves version from explicit version string and finalizes" do
+      version_file = Tempfile.new
+      version_file << "module MyGem\n  VERSION = \"Unreleased\"\n  RELEASE_DATE = \"Unreleased\"\nend\n"
+      version_file.close
+
+      changelog_file = Tempfile.new
+      changelog_file << <<~MD
+        # Changelog
+
+        All notable changes.
+
+        ## [Unreleased]
+
+        ### Added
+
+        - New feature
+
+        ## [1.0.0] - 2026-03-01
+
+        ### Added
+
+        - Initial release
+      MD
+      changelog_file.close
+
+      version, date = Reissue.deferred_finalize(
+        "2026-03-06",
+        version: "1.1.0",
+        changelog_file: changelog_file.path,
+        version_file: version_file.path
+      )
+
+      assert_equal "1.1.0", version
+      assert_equal "2026-03-06", date
+
+      version_contents = File.read(version_file)
+      assert_match(/VERSION = "1.1.0"/, version_contents)
+      assert_match(/RELEASE_DATE = "2026-03-06"/, version_contents)
+
+      changelog_contents = File.read(changelog_file)
+      assert_match(/\[1.1.0\] - 2026-03-06/, changelog_contents)
+      refute_match(/Unreleased/, changelog_contents)
+      assert_match(/New feature/, changelog_contents)
+    end
+
+    it "resolves version from segment and git tag" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          setup_git_repo_with_custom_tag("v1.0.0")
+          create_commit_with_trailer("Add stuff", "Added: Cool feature")
+
+          version_file = "lib/test/version.rb"
+          FileUtils.mkdir_p("lib/test")
+          File.write(version_file, "module Test\n  VERSION = \"Unreleased\"\n  RELEASE_DATE = \"Unreleased\"\nend\n")
+
+          File.write("CHANGELOG.md", <<~MD)
+            # Changelog
+
+            All notable changes.
+
+            ## [Unreleased]
+
+            ### Added
+
+            - Manual entry
+
+            ## [1.0.0] - 2026-03-01
+
+            ### Added
+
+            - Initial release
+          MD
+
+          version, date = Reissue.deferred_finalize(
+            "2026-03-06",
+            segment: "minor",
+            changelog_file: "CHANGELOG.md",
+            version_file: version_file
+          )
+
+          assert_equal "1.1.0", version
+          assert_equal "2026-03-06", date
+
+          version_contents = File.read(version_file)
+          assert_match(/VERSION = "1.1.0"/, version_contents)
+        end
+      end
+    end
+
+    it "errors when no version can be determined" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          system("git init -q && git config user.name 'Test' && git config user.email 'test@test.com'", out: File::NULL, err: File::NULL)
+          File.write("README.md", "hi")
+          system("git add . && git commit -q -m 'init'", out: File::NULL, err: File::NULL)
+
+          version_file = "version.rb"
+          File.write(version_file, "module Test\n  VERSION = \"Unreleased\"\nend\n")
+
+          File.write("CHANGELOG.md", <<~MD)
+            # Changelog
+
+            ## [Unreleased]
+          MD
+
+          error = assert_raises(RuntimeError) do
+            Reissue.deferred_finalize(
+              "2026-03-06",
+              changelog_file: "CHANGELOG.md",
+              version_file: version_file
+            )
+          end
+
+          assert_match(/Cannot determine next version/, error.message)
+        end
+      end
+    end
+  end
+
   describe ".clear_fragments" do
     it "clears all fragment files in the directory" do
       Dir.mktmpdir do |tempdir|

--- a/test/test_reissue.rb
+++ b/test/test_reissue.rb
@@ -424,6 +424,78 @@ class TestReissue < Minitest::Spec
     Dir.chdir(@original_dir)
   end
 
+  describe ".deferred_call" do
+    it "sets VERSION to Unreleased and adds Unreleased changelog entry" do
+      version_file = Tempfile.new
+      version_file << "module MyGem\n  VERSION = \"1.0.0\"\n  RELEASE_DATE = \"2026-03-01\"\nend\n"
+      version_file.close
+
+      changelog_file = Tempfile.new
+      changelog_file << <<~MD
+        # Changelog
+
+        All notable changes.
+
+        ## [1.0.0] - 2026-03-01
+
+        ### Added
+
+        - Initial release
+      MD
+      changelog_file.close
+
+      Reissue.deferred_call(version_file:, changelog_file:)
+
+      version_contents = File.read(version_file)
+      assert_match(/VERSION = "Unreleased"/, version_contents)
+      assert_match(/RELEASE_DATE = "Unreleased"/, version_contents)
+
+      changelog_contents = File.read(changelog_file)
+      assert_match(/## \[Unreleased\]\n/, changelog_contents)
+      refute_match(/## \[Unreleased\] -/, changelog_contents)
+      assert_match(/## \[1.0.0\] - 2026-03-01/, changelog_contents)
+    end
+
+    it "works without RELEASE_DATE in version file" do
+      version_file = Tempfile.new
+      version_file << "module MyGem\n  VERSION = \"1.0.0\"\nend\n"
+      version_file.close
+
+      changelog_file = Tempfile.new
+      changelog_file << <<~MD
+        # Changelog
+
+        All notable changes.
+
+        ## [1.0.0] - 2026-03-01
+
+        ### Added
+
+        - Initial release
+      MD
+      changelog_file.close
+
+      Reissue.deferred_call(version_file:, changelog_file:)
+
+      version_contents = File.read(version_file)
+      assert_match(/VERSION = "Unreleased"/, version_contents)
+
+      changelog_contents = File.read(changelog_file)
+      assert_match(/## \[Unreleased\]\n/, changelog_contents)
+    end
+
+    it "works without a changelog file" do
+      version_file = Tempfile.new
+      version_file << "module MyGem\n  VERSION = \"1.0.0\"\nend\n"
+      version_file.close
+
+      Reissue.deferred_call(version_file:, changelog_file: nil)
+
+      version_contents = File.read(version_file)
+      assert_match(/VERSION = "Unreleased"/, version_contents)
+    end
+  end
+
   describe ".clear_fragments" do
     it "clears all fragment files in the directory" do
       Dir.mktmpdir do |tempdir|

--- a/test/test_reissue_deferred_task.rb
+++ b/test/test_reissue_deferred_task.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "reissue/rake"
+require "rake"
+
+class TestReissueDeferredTask < Minitest::Spec
+  before do
+    @original_dir = Dir.pwd
+    @tmpdir = Dir.mktmpdir
+    Dir.chdir(@tmpdir)
+
+    system("git init -q && git config user.name 'Test' && git config user.email 'test@test.com'", out: File::NULL, err: File::NULL)
+
+    FileUtils.mkdir_p("lib/test")
+    File.write("lib/test/version.rb", <<~RUBY)
+      module Test
+        VERSION = "1.0.0"
+        RELEASE_DATE = "2026-03-01"
+      end
+    RUBY
+
+    File.write("CHANGELOG.md", <<~MD)
+      # Changelog
+
+      All notable changes.
+
+      ## [1.0.0] - 2026-03-01
+
+      ### Added
+
+      - Initial release
+    MD
+
+    system("git add . && git commit -q -m 'Release 1.0.0'", out: File::NULL, err: File::NULL)
+    system("git tag v1.0.0")
+
+    Rake::Task.clear
+  end
+
+  after do
+    Dir.chdir(@original_dir)
+    FileUtils.remove_entry @tmpdir
+  end
+
+  describe "deferred_versioning configuration" do
+    it "defaults to false" do
+      task = Reissue::Task.create :reissue do |t|
+        t.version_file = "lib/test/version.rb"
+        t.commit = false
+      end
+      refute task.deferred_versioning
+    end
+
+    it "can be set to true" do
+      task = Reissue::Task.create :reissue do |t|
+        t.version_file = "lib/test/version.rb"
+        t.deferred_versioning = true
+        t.commit = false
+      end
+      assert task.deferred_versioning
+    end
+  end
+
+  describe "deferred reissue task" do
+    it "sets VERSION to Unreleased instead of bumping" do
+      Reissue::Task.create :reissue do |t|
+        t.version_file = "lib/test/version.rb"
+        t.deferred_versioning = true
+        t.commit = false
+      end
+
+      Rake::Task[:reissue].invoke
+
+      version_contents = File.read("lib/test/version.rb")
+      assert_match(/VERSION = "Unreleased"/, version_contents)
+
+      changelog_contents = File.read("CHANGELOG.md")
+      assert_match(/## \[Unreleased\]/, changelog_contents)
+    end
+  end
+
+  describe "deferred finalize task" do
+    it "resolves version from segment argument" do
+      Reissue::Task.create :reissue do |t|
+        t.version_file = "lib/test/version.rb"
+        t.deferred_versioning = true
+        t.commit = false
+        t.commit_finalize = false
+      end
+
+      # First run deferred post-release
+      Rake::Task[:reissue].invoke
+
+      # Then finalize with segment
+      Rake::Task["reissue:finalize"].invoke("patch")
+
+      version_contents = File.read("lib/test/version.rb")
+      assert_match(/VERSION = "1.0.1"/, version_contents)
+
+      changelog_contents = File.read("CHANGELOG.md")
+      assert_match(/\[1.0.1\]/, changelog_contents)
+      refute_match(/Unreleased/, changelog_contents)
+    end
+  end
+end

--- a/test/test_version_updater.rb
+++ b/test/test_version_updater.rb
@@ -84,6 +84,34 @@ class TestVersionUpdater < Minitest::Spec
     end
   end
 
+  describe "set_version" do
+    it "writes an arbitrary version string to the version file" do
+      file = File.expand_path("fixtures/version.rb", __dir__)
+      tempfile = Tempfile.new
+      tempfile << File.read(file)
+      tempfile.close
+      updater = Reissue::VersionUpdater.new(tempfile.path)
+
+      updater.set_version("Unreleased", version_file: tempfile.path)
+
+      contents = File.read(tempfile.path)
+      assert_match(/VERSION = "Unreleased"/, contents)
+    end
+
+    it "writes an arbitrary version string to a file with RELEASE_DATE" do
+      file = File.expand_path("fixtures/version_with_release_date.rb", __dir__)
+      tempfile = Tempfile.new
+      tempfile << File.read(file)
+      tempfile.close
+      updater = Reissue::VersionUpdater.new(tempfile.path)
+
+      updater.set_version("Unreleased", version_file: tempfile.path)
+
+      contents = File.read(tempfile.path)
+      assert_match(/VERSION = "Unreleased"/, contents)
+    end
+  end
+
   describe "update_release_date" do
     it "updates RELEASE_DATE in the version file" do
       file = File.expand_path("fixtures/version_with_release_date.rb", __dir__)


### PR DESCRIPTION
Allow projects to wait until later to determine the version.
All commits after a release will be committed to an unreleased version, neither a new version nor the prior released version.

Projects can work where the version goes:
"Unreleased" => "1.0.0" => "Unreleased" => whatever is calculated from git trailers for the next version.

## Summary

- Adds `deferred_versioning` configuration flag for projects that want to defer version decisions until release time
- Post-release sets `VERSION = "Unreleased"` and adds `## [Unreleased]` to changelog instead of bumping
- At finalize time, resolves version from explicit argument, segment + git tag, or git trailers
- Supports Rake task, Gem integration, and Hoe plugin

## Changes

- Parser/Printer handle `## [Unreleased]` entries (no date field)
- `ChangelogUpdater#finalize` accepts `resolved_version:` to replace Unreleased
- `VersionUpdater#set_version` writes arbitrary version strings
- `Reissue.deferred_call` for post-release in deferred mode
- `Reissue.deferred_finalize` for resolving version at release time
- `deferred_versioning` flag on `Reissue::Task` and Hoe plugin

## Test plan

- [x] 20 new tests covering unit and integration scenarios
- [x] Full suite: 160 tests, 498 assertions, 0 failures
- [x] Linter clean (standardrb)
- [x] Backward compatible — all existing tests pass unchanged