### PR TITLE
Sort changelog sections by configured order when printing

### DIFF
--- a/lib/reissue/printer.rb
+++ b/lib/reissue/printer.rb
@@ -29,7 +29,7 @@ module Reissue
         else
           "## [#{version}] - #{date}"
         end
-        changes_string = changes.map do |section, section_changes|
+        changes_string = sorted_change_pairs(changes).map do |section, section_changes|
           format_section(section, section_changes)
         end.join("\n\n")
         [version_string, changes_string].reject { |str| str.empty? }.join("\n\n")
@@ -48,6 +48,14 @@ module Reissue
 
         #{changes.map { |change| "- #{change}" }.join("\n")}
       MARKDOWN
+    end
+
+    # Keep section order aligned with rake / Reissue.changelog_sections (same rule as preview task).
+    def sorted_change_pairs(changes)
+      changes.sort_by do |section, _|
+        idx = Reissue.changelog_sections.index(section) || 999
+        [idx, section.to_s]
+      end
     end
   end
 end

--- a/test/test_printer.rb
+++ b/test/test_printer.rb
@@ -87,5 +87,30 @@ class TestPrinter < Minitest::Spec
         ## [0.0.0] - Unreleased
       MARKDOWN
     end
+
+    it "orders change sections by Reissue.changelog_sections, not hash insertion order" do
+      saved = Reissue.changelog_sections.dup
+      Reissue.changelog_sections = %w[Security Fixed Added Changed]
+
+      changelog = {
+        "versions" => [
+          {
+            "version" => "1.0.0",
+            "date" => "2021-01-01",
+            "changes" => {
+              "Added" => ["feature"],
+              "Security" => ["cve"],
+              "Fixed" => ["bug"]
+            }
+          }
+        ]
+      }
+      printer = Reissue::Printer.new(changelog)
+      body = printer.to_s
+      assert_operator body.index("### Security"), :<, body.index("### Fixed")
+      assert_operator body.index("### Fixed"), :<, body.index("### Added")
+    ensure
+      Reissue.changelog_sections = saved
+    end
   end
 end


### PR DESCRIPTION
Release and fragment merge built section order from hash insertion
(glob or commit order), not task.changelog_sections. Printer now
uses the same sort rule as the preview task.

Fixed: changelog sections not following changelog_sections order on release