### PR TITLE
Add runbook_file option for post-release runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,54 @@ Version trailers are case-insensitive:
 - **New features:** Use `Version: minor` for backwards-compatible new functionality
 - **Bug fixes:** Use `Version: patch` for backwards-compatible bug fixes (or omit - patch is the default post-release bump)
 
+## Post-release Runbook
+
+Reissue can maintain a runbook file listing manual steps to perform after a release — run a rake task, clean up data, re-index documents, and so on. This is aimed at applications; gems are unlikely to need it.
+
+```ruby
+Reissue::Task.create :reissue do |task|
+  task.version_file = "config/version.rb"
+  task.fragment = :git
+  task.runbook_file = "RUNBOOK.md"  # Default: nil (disabled)
+end
+```
+
+The runbook holds only the latest release. Items are checkboxes so operators can tick them off:
+
+```markdown
+# Runbook
+
+Steps to perform after releasing the version below.
+
+## [1.2.3] - 2026-07-21
+
+- [ ] Run `rake data:cleanup` (abc1234)
+- [ ] Re-index search documents (def5678)
+```
+
+### Adding Runbook Items
+
+Add `Runbook:` trailers to commit messages (case-insensitive, independent of the `fragment` setting):
+
+```bash
+git commit -m "Add data migration
+
+Fixed: Duplicate user records
+Runbook: Run \`rake data:cleanup\` after deploy"
+```
+
+You can also edit the checklist under `## [Unreleased]` directly; direct edits and trailers are merged and deduplicated.
+
+Note: `Runbook:` is reserved for the runbook — do not add "Runbook" to `changelog_sections`.
+
+### Lifecycle
+
+1. **During development** — items accumulate from `Runbook:` trailers and direct edits.
+2. **Finalize** (`rake reissue:finalize` / before `rake build`) — trailers since the last version tag are merged into the file and the header is stamped with the release version and date, matching the changelog. The file is committed with the finalize commit, so the release tag contains the finalized runbook.
+3. **New version setup** (`rake reissue` after release) — the runbook is cleared back to a header-only `## [Unreleased]` section. Prior runbooks remain reachable via release tags.
+
+`rake reissue:preview` also shows pending runbook items when `runbook_file` is configured.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt.

--- a/lib/reissue.rb
+++ b/lib/reissue.rb
@@ -4,6 +4,7 @@ require_relative "reissue/version"
 require_relative "reissue/version_updater"
 require_relative "reissue/changelog_updater"
 require_relative "reissue/fragment_handler"
+require_relative "reissue/runbook"
 
 # Reissue is a module that provides functionality for updating version numbers and changelogs.
 module Reissue
@@ -40,7 +41,8 @@ module Reissue
     version_redo_proc: nil,
     fragment: nil,
     fragment_directory: nil,
-    tag_pattern: nil
+    tag_pattern: nil,
+    runbook_file: nil
   )
     # Handle deprecation
     if fragment_directory && !fragment
@@ -55,10 +57,11 @@ module Reissue
       changelog_updater = ChangelogUpdater.new(changelog_file)
       changelog_updater.call(new_version, date:, changes:, changelog_file:, version_limit:, retain_changelogs:, fragment:, tag_pattern:)
     end
+    Runbook.new(runbook_file).clear if runbook_file
     new_version
   end
 
-  def self.deferred_call(version_file:, changelog_file: "CHANGELOG.md", version_limit: 2, retain_changelogs: false, fragment: nil, tag_pattern: nil)
+  def self.deferred_call(version_file:, changelog_file: "CHANGELOG.md", version_limit: 2, retain_changelogs: false, fragment: nil, tag_pattern: nil, runbook_file: nil)
     version_updater = VersionUpdater.new(version_file)
     version_updater.set_version("Unreleased", version_file:)
     version_updater.update_release_date("Unreleased", version_file:)
@@ -68,10 +71,11 @@ module Reissue
       changelog_updater.call("Unreleased", date: nil, changes: {}, changelog_file:, version_limit:, retain_changelogs:, fragment:, tag_pattern:)
     end
 
+    Runbook.new(runbook_file).clear if runbook_file
     "Unreleased"
   end
 
-  def self.deferred_finalize(date = Date.today, version: nil, segment: nil, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, tag_pattern: nil, version_file: nil, version_redo_proc: nil)
+  def self.deferred_finalize(date = Date.today, version: nil, segment: nil, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, tag_pattern: nil, version_file: nil, version_redo_proc: nil, runbook_file: nil)
     resolved_version = if version&.match?(/^\d/)
       version
     elsif segment || version
@@ -145,7 +149,14 @@ module Reissue
     end
 
     changelog = changelog_updater.finalize(date: date, changelog_file: changelog_file, retain_changelogs: retain_changelogs, resolved_version: resolved_version)
-    changelog["versions"].first.slice("version", "date").values
+    changelog["versions"].first.slice("version", "date").values.tap do |finalized_version, finalized_date|
+      finalize_runbook(runbook_file, version: finalized_version, date: finalized_date, tag_pattern:) if runbook_file
+    end
+  end
+
+  private_class_method def self.finalize_runbook(runbook_file, version:, date:, tag_pattern: nil)
+    trailer_items = FragmentHandler.for(:git, tag_pattern:).read_runbook_entries
+    Runbook.new(runbook_file).finalize(version:, date:, trailer_items:)
   end
 
   private_class_method def self.resolve_version_from_tag(segment, tag_pattern: nil, version_redo_proc: nil)
@@ -165,7 +176,7 @@ module Reissue
   # @param fragment_directory [String] @deprecated Use fragment parameter instead
   #
   # @return [Array] The version number and release date.
-  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil, version_file: nil)
+  def self.finalize(date = Date.today, changelog_file: "CHANGELOG.md", retain_changelogs: false, fragment: nil, fragment_directory: nil, tag_pattern: nil, version_file: nil, runbook_file: nil)
     # Handle deprecation
     if fragment_directory && !fragment
       warn "[DEPRECATION] `fragment_directory` parameter is deprecated. Please use `fragment` instead."
@@ -224,7 +235,9 @@ module Reissue
       version_updater.update_release_date(date.to_s, version_file:)
     end
 
-    changelog["versions"].first.slice("version", "date").values
+    changelog["versions"].first.slice("version", "date").values.tap do |finalized_version, finalized_date|
+      finalize_runbook(runbook_file, version: finalized_version, date: finalized_date, tag_pattern:) if runbook_file
+    end
   end
 
   # Reformats the changelog file to ensure it is correctly formatted.

--- a/lib/reissue/fragment_handler/git_fragment_handler.rb
+++ b/lib/reissue/fragment_handler/git_fragment_handler.rb
@@ -44,6 +44,16 @@ module Reissue
         find_last_tag
       end
 
+      # Read runbook entries from git commit trailers
+      #
+      # @return [Array<String>] Runbook items with the short SHA appended
+      def read_runbook_entries
+        return [] unless git_available? && in_git_repo?
+
+        commits = commits_since_last_tag
+        parse_runbook_entries_from_commits(commits)
+      end
+
       # Read version bump from git commit trailers
       #
       # @return [Symbol, nil] One of :major, :minor, :patch, or nil if none found
@@ -183,6 +193,44 @@ module Reissue
         end
 
         result
+      end
+
+      RUNBOOK_TRAILER_REGEX = /^runbook:\s*(.+)$/i
+
+      def parse_runbook_entries_from_commits(commits)
+        entries = []
+
+        commits.each do |commit|
+          sha = commit[:sha]
+          lines = commit[:message].lines
+
+          i = 0
+          while i < lines.length
+            line = lines[i].rstrip
+            i += 1
+            next if line.strip.empty?
+
+            if (match = line.match(RUNBOOK_TRAILER_REGEX))
+              trailer_value = match[1].strip
+
+              # Collect continuation lines (non-empty lines that don't start a new trailer)
+              while i < lines.length
+                next_line = lines[i].rstrip
+                break if next_line.strip.empty?
+                break if next_line.match(RUNBOOK_TRAILER_REGEX)
+                break if next_line.match(trailer_regex)
+                break if next_line.match?(/^[A-Za-z][\w-]+:\s/)
+
+                trailer_value += " #{next_line.strip}"
+                i += 1
+              end
+
+              entries << "#{trailer_value} (#{sha})"
+            end
+          end
+        end
+
+        entries
       end
 
       def normalize_section_name(name)

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -37,6 +37,12 @@ module Reissue
     # Provide a callable to decide how to store the files.
     attr_accessor :retain_changelogs
 
+    # The path to a runbook file listing steps to perform after a release.
+    # Populated from "Runbook:" git trailers or direct edits, finalized with
+    # the release version, and cleared when a new version is prepared.
+    # Default: nil (disabled).
+    attr_accessor :runbook_file
+
     # The fragment configuration for changelog entries.
     # @return [String, nil] nil (disabled) or a directory path string for fragment files
     # @example Using directory-based fragments
@@ -126,6 +132,7 @@ module Reissue
       @updated_paths = []
       @changelog_file = "CHANGELOG.md"
       @retain_changelogs = false
+      @runbook_file = nil
       @fragment = nil
       @clear_fragments = false
       @commit = true
@@ -187,9 +194,9 @@ module Reissue
       !status.success?
     end
 
-    # Stage updated_paths that exist on disk.
+    # Stage updated_paths (and the runbook file) that exist on disk.
     def stage_updated_paths
-      existing = updated_paths.select { |p| File.exist?(p) }
+      existing = (updated_paths + [runbook_file].compact).select { |p| File.exist?(p) }
       if existing.any?
         run_command("git add #{existing.join(" ")}", "Failed to stage additional paths: #{existing.join(", ")}")
       end
@@ -206,7 +213,8 @@ module Reissue
             changelog_file:,
             version_limit:,
             fragment: fragment,
-            tag_pattern:
+            tag_pattern:,
+            runbook_file:
           )
         else
           segment = args[:segment] || "patch"
@@ -217,7 +225,8 @@ module Reissue
             version_limit:,
             version_redo_proc:,
             fragment: fragment,
-            tag_pattern:
+            tag_pattern:,
+            runbook_file:
           )
         end
         bundle
@@ -287,7 +296,8 @@ module Reissue
             fragment: fragment,
             tag_pattern:,
             version_file:,
-            version_redo_proc:
+            version_redo_proc:,
+            runbook_file:
           )
         else
           date = args[:version_or_segment] || Time.now.strftime("%Y-%m-%d")
@@ -297,7 +307,8 @@ module Reissue
             retain_changelogs:,
             fragment: fragment,
             tag_pattern:,
-            version_file:
+            version_file:,
+            runbook_file:
           )
         end
 
@@ -374,6 +385,20 @@ module Reissue
         else
           puts "Fragment handling is not configured."
           puts "Set task.fragment to a directory path or :git to enable changelog fragments."
+        end
+
+        if runbook_file
+          require_relative "fragment_handler"
+          runbook_entries = Reissue::FragmentHandler.for(:git, tag_pattern: tag_pattern).read_runbook_entries
+
+          puts
+          if runbook_entries.empty?
+            puts "No runbook items found."
+            puts "  (No Runbook: trailers found since last version tag)"
+          else
+            puts "Runbook items that will be added to #{runbook_file}:\n\n"
+            runbook_entries.each { |item| puts "- [ ] #{item}" }
+          end
         end
       end
 
@@ -486,6 +511,9 @@ namespace :reissue do
         task.fragment = :git                      # Use git commit trailers (Added:, Fixed:, etc.)
         # task.fragment = "changelog_fragments"   # Or use a directory of fragment files
         task.clear_fragments = false              # Clear fragment files after release. Not necessary when using git trailers.
+
+        # Post-release runbook (mainly for applications)
+        # task.runbook_file = "RUNBOOK.md"        # Maintain a runbook from Runbook: git trailers
 
         # Git workflow options
         task.commit = true                        # Auto-commit version bumps

--- a/lib/reissue/runbook.rb
+++ b/lib/reissue/runbook.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Reissue
+  # Maintains a post-release runbook file listing steps to perform after
+  # releasing a version. The file holds only the latest release.
+  class Runbook
+    ITEM_PATTERN = /^- (?:\[(?<checked>[ xX])\] )?(?<text>.+)$/
+
+    def initialize(runbook_file)
+      @runbook_file = runbook_file
+    end
+
+    attr_reader :runbook_file
+
+    # Writes a header-only template for the given version.
+    def generate(version: "Unreleased")
+      File.write(runbook_file, template(heading(version)))
+    end
+
+    alias_method :clear, :generate
+
+    # Returns the text of each checklist item, without checkbox markers.
+    def items
+      parsed_items.map { |item| item[:text] }
+    end
+
+    # Stamps the header with the release version and date, merging directly
+    # edited items with trailer items (deduplicated by text).
+    def finalize(version:, date:, trailer_items: [])
+      merged = parsed_items
+      texts = merged.map { |item| item[:text] }
+      trailer_items.each do |text|
+        merged << {text: text, checked: false} unless texts.include?(text)
+      end
+      File.write(runbook_file, template(heading(version, date), merged))
+    end
+
+    private
+
+    def parsed_items
+      return [] unless File.exist?(runbook_file)
+
+      File.read(runbook_file).lines.filter_map do |line|
+        match = line.rstrip.match(ITEM_PATTERN)
+        next unless match
+        {text: match[:text], checked: match[:checked]&.downcase == "x"}
+      end
+    end
+
+    def heading(version, date = nil)
+      date ? "## [#{version}] - #{date}" : "## [#{version}]"
+    end
+
+    def template(heading, items = [])
+      header = <<~MARKDOWN
+        # Runbook
+
+        Steps to perform after releasing the version below.
+
+        #{heading}
+      MARKDOWN
+      return header if items.empty?
+
+      list = items.map { |item| "- [#{item[:checked] ? "x" : " "}] #{item[:text]}" }.join("\n")
+      "#{header}\n#{list}\n"
+    end
+  end
+end

--- a/test/test_git_runbook_trailers.rb
+++ b/test/test_git_runbook_trailers.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "reissue/fragment_handler"
+require "tmpdir"
+
+class TestGitRunbookTrailers < Minitest::Test
+  def test_extracts_runbook_trailers_with_sha
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo
+        create_commit("Add cleanup task\n\nRunbook: Run `rake data:cleanup`")
+
+        handler = Reissue::FragmentHandler.for(:git)
+        entries = handler.read_runbook_entries
+
+        assert_equal 1, entries.length
+        assert_match(/\ARun `rake data:cleanup` \(\h{7,}\)\z/, entries.first)
+      end
+    end
+  end
+
+  def test_trailer_key_is_case_insensitive
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo
+        create_commit("One\n\nrunbook: lowercase step")
+        create_commit("Two\n\nRUNBOOK: uppercase step")
+
+        handler = Reissue::FragmentHandler.for(:git)
+        entries = handler.read_runbook_entries
+
+        assert_equal 2, entries.length
+        assert_match(/\Alowercase step/, entries[0])
+        assert_match(/\Auppercase step/, entries[1])
+      end
+    end
+  end
+
+  def test_joins_continuation_lines
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo
+        create_commit("Add step\n\nRunbook: Run the cleanup\n  and verify the results")
+
+        handler = Reissue::FragmentHandler.for(:git)
+        entries = handler.read_runbook_entries
+
+        assert_equal 1, entries.length
+        assert_match(/\ARun the cleanup and verify the results/, entries.first)
+      end
+    end
+  end
+
+  def test_only_reads_commits_since_last_tag
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo
+        create_commit("Old\n\nRunbook: old step")
+        create_tag("v1.0.0")
+        create_commit("New\n\nRunbook: new step")
+
+        handler = Reissue::FragmentHandler.for(:git)
+        entries = handler.read_runbook_entries
+
+        assert_equal 1, entries.length
+        assert_match(/\Anew step/, entries.first)
+      end
+    end
+  end
+
+  def test_returns_empty_array_without_trailers
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo
+        create_commit("No trailers here")
+
+        handler = Reissue::FragmentHandler.for(:git)
+
+        assert_empty handler.read_runbook_entries
+      end
+    end
+  end
+
+  def test_runbook_trailers_are_not_changelog_entries
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo
+        create_commit("Mixed\n\nFixed: a bug\nRunbook: a manual step")
+
+        handler = Reissue::FragmentHandler.for(:git)
+        changelog_entries = handler.read
+
+        assert changelog_entries.key?("Fixed")
+        refute changelog_entries.key?("Runbook")
+      end
+    end
+  end
+
+  private
+
+  def setup_git_repo
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+    File.write("test.txt", "initial")
+    system("git add test.txt", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial commit'", out: File::NULL, err: File::NULL)
+  end
+
+  def create_tag(tag_name)
+    sleep(0.1)
+    system("git tag -a #{tag_name} -m 'Release #{tag_name}'", out: File::NULL, err: File::NULL)
+  end
+
+  def create_commit(message)
+    filename = "file_#{Time.now.to_f}.txt"
+    File.write(filename, "content")
+    system("git add #{filename}", out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", message, out: File::NULL, err: File::NULL)
+  end
+end

--- a/test/test_rake_runbook_file_option.rb
+++ b/test/test_rake_runbook_file_option.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+require "tmpdir"
+
+class TestRakeRunbookFileOption < Minitest::Test
+  def setup
+    @rake = Rake::Application.new
+    Rake.application = @rake
+  end
+
+  def teardown
+    Rake.application.clear
+  end
+
+  def test_reissue_task_clears_runbook
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.3")
+        write_changelog("1.2.3", date: "2026-07-01")
+        File.write("RUNBOOK.md", <<~MD)
+          # Runbook
+
+          Steps to perform after releasing the version below.
+
+          ## [1.2.3] - 2026-07-01
+
+          - [ ] Old step
+        MD
+        commit_file("RUNBOOK.md", "Add runbook")
+
+        create_rakefile(commit: false)
+        load "Rakefile"
+
+        capture_io { Rake::Task["reissue"].invoke("patch") }
+
+        contents = File.read("RUNBOOK.md")
+        assert_match(/## \[Unreleased\]/, contents)
+        refute_match(/Old step/, contents)
+      end
+    end
+  end
+
+  def test_finalize_task_stamps_runbook_matching_changelog
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.4")
+        write_changelog("1.2.4", date: "Unreleased")
+        File.write("RUNBOOK.md", <<~MD)
+          # Runbook
+
+          Steps to perform after releasing the version below.
+
+          ## [Unreleased]
+
+          - [ ] Manual step
+        MD
+        commit_file("RUNBOOK.md", "Add runbook\n\nRunbook: Run `rake data:cleanup`")
+
+        create_rakefile(commit_finalize: false)
+        load "Rakefile"
+
+        capture_io { Rake::Task["reissue:finalize"].invoke("2026-07-21") }
+
+        runbook = File.read("RUNBOOK.md")
+        changelog = File.read("CHANGELOG.md")
+        assert_match(/## \[1\.2\.4\] - 2026-07-21/, changelog)
+        assert_match(/## \[1\.2\.4\] - 2026-07-21/, runbook)
+        assert_match(/- \[ \] Manual step/, runbook)
+        assert_match(/- \[ \] Run `rake data:cleanup` \(\h{7,}\)/, runbook)
+      end
+    end
+  end
+
+  def test_finalize_task_commits_newly_created_runbook
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.4")
+        write_changelog("1.2.4", date: "Unreleased")
+        commit_file("CHANGELOG.md", "Update changelog")
+
+        create_rakefile(commit_finalize: true)
+        load "Rakefile"
+
+        capture_io { Rake::Task["reissue:finalize"].invoke("2026-07-21") }
+
+        assert File.exist?("RUNBOOK.md")
+        status = `git status --porcelain`
+        refute_match(/RUNBOOK\.md/, status, "RUNBOOK.md should be committed")
+        committed_files = `git show --name-only --format= HEAD`
+        assert_match(/RUNBOOK\.md/, committed_files)
+      end
+    end
+  end
+
+  def test_preview_task_shows_runbook_entries
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.3")
+        commit_file("note.txt", "Add cleanup\n\nRunbook: Run the cleanup task")
+
+        create_rakefile
+        load "Rakefile"
+
+        output, _ = capture_io { Rake::Task["reissue:preview"].invoke }
+
+        assert_match(/Runbook items/, output)
+        assert_match(/Run the cleanup task/, output)
+      end
+    end
+  end
+
+  private
+
+  def setup_git_repo_with_version(version)
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+    File.write("version.rb", "VERSION = \"#{version}\"")
+    system("git add version.rb", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial version'", out: File::NULL, err: File::NULL)
+    system("git tag v1.2.3", out: File::NULL, err: File::NULL)
+  end
+
+  def write_changelog(version, date:)
+    File.write("CHANGELOG.md", <<~MD)
+      # Changelog
+
+      ## [#{version}] - #{date}
+
+      ### Added
+
+      - Existing feature
+    MD
+  end
+
+  def commit_file(filename, message)
+    File.write(filename, File.exist?(filename) ? File.read(filename) : "content") unless File.exist?(filename)
+    system("git add #{filename}", out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", message, out: File::NULL, err: File::NULL)
+  end
+
+  def create_rakefile(commit: false, commit_finalize: false)
+    File.write("Rakefile", <<~RUBY)
+      require "reissue/rake"
+
+      Reissue::Task.create :reissue do |task|
+        task.version_file = "version.rb"
+        task.fragment = :git
+        task.runbook_file = "RUNBOOK.md"
+        task.commit = #{commit}
+        task.commit_finalize = #{commit_finalize}
+        task.push_reissue = false
+        task.push_finalize = false
+      end
+    RUBY
+  end
+end

--- a/test/test_reissue_runbook.rb
+++ b/test/test_reissue_runbook.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+require "fileutils"
+
+class TestReissueRunbook < Minitest::Spec
+  VERSION_FILE_CONTENT = <<~RUBY
+    module Reissue
+      module FakeGem
+        VERSION = "0.1.0"
+      end
+    end
+  RUBY
+
+  CHANGELOG_CONTENT = <<~MD
+    # Changelog
+
+    All notable changes to this project will be documented in this file.
+
+    ## [1.0.0] - Unreleased
+
+    ### Added
+
+    - New feature
+  MD
+
+  FINALIZED_RUNBOOK = <<~MD
+    # Runbook
+
+    Steps to perform after releasing the version below.
+
+    ## [0.9.0] - 2026-01-01
+
+    - [x] Old step
+  MD
+
+  describe ".call with runbook_file" do
+    it "clears the runbook for the new unreleased version" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("version.rb", VERSION_FILE_CONTENT)
+          File.write("CHANGELOG.md", CHANGELOG_CONTENT)
+          File.write("RUNBOOK.md", FINALIZED_RUNBOOK)
+
+          Reissue.call(version_file: "version.rb", changelog_file: "CHANGELOG.md", runbook_file: "RUNBOOK.md")
+
+          contents = File.read("RUNBOOK.md")
+          assert_match(/## \[Unreleased\]/, contents)
+          refute_match(/0\.9\.0/, contents)
+          refute_match(/Old step/, contents)
+        end
+      end
+    end
+
+    it "creates the runbook when it does not exist" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("version.rb", VERSION_FILE_CONTENT)
+          File.write("CHANGELOG.md", CHANGELOG_CONTENT)
+
+          Reissue.call(version_file: "version.rb", changelog_file: "CHANGELOG.md", runbook_file: "RUNBOOK.md")
+
+          assert File.exist?("RUNBOOK.md")
+          assert_match(/## \[Unreleased\]/, File.read("RUNBOOK.md"))
+        end
+      end
+    end
+
+    it "does not create a runbook when runbook_file is nil" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("version.rb", VERSION_FILE_CONTENT)
+          File.write("CHANGELOG.md", CHANGELOG_CONTENT)
+
+          Reissue.call(version_file: "version.rb", changelog_file: "CHANGELOG.md")
+
+          refute File.exist?("RUNBOOK.md")
+        end
+      end
+    end
+  end
+
+  describe ".finalize with runbook_file" do
+    it "stamps the runbook with the changelog version and date, merging git trailers" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          setup_git_repo
+          create_tag("v0.9.0")
+          create_commit("Add cleanup\n\nRunbook: Run cleanup")
+
+          File.write("CHANGELOG.md", CHANGELOG_CONTENT)
+          File.write("RUNBOOK.md", <<~MD)
+            # Runbook
+
+            Steps to perform after releasing the version below.
+
+            ## [Unreleased]
+
+            - [ ] Manual step
+          MD
+
+          Reissue.finalize("2026-07-21", changelog_file: "CHANGELOG.md", runbook_file: "RUNBOOK.md")
+
+          contents = File.read("RUNBOOK.md")
+          assert_match(/## \[1\.0\.0\] - 2026-07-21/, contents)
+          assert_match(/- \[ \] Manual step/, contents)
+          assert_match(/- \[ \] Run cleanup \(\h{7,}\)/, contents)
+        end
+      end
+    end
+
+    it "stamps the runbook outside a git repository using direct edits only" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("CHANGELOG.md", CHANGELOG_CONTENT)
+          File.write("RUNBOOK.md", <<~MD)
+            # Runbook
+
+            Steps to perform after releasing the version below.
+
+            ## [Unreleased]
+
+            - [ ] Manual step
+          MD
+
+          Reissue.finalize("2026-07-21", changelog_file: "CHANGELOG.md", runbook_file: "RUNBOOK.md")
+
+          contents = File.read("RUNBOOK.md")
+          assert_match(/## \[1\.0\.0\] - 2026-07-21/, contents)
+          assert_match(/- \[ \] Manual step/, contents)
+        end
+      end
+    end
+  end
+
+  describe ".deferred_call with runbook_file" do
+    it "clears the runbook for the new unreleased version" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("version.rb", VERSION_FILE_CONTENT)
+          File.write("CHANGELOG.md", CHANGELOG_CONTENT)
+          File.write("RUNBOOK.md", FINALIZED_RUNBOOK)
+
+          Reissue.deferred_call(version_file: "version.rb", changelog_file: "CHANGELOG.md", runbook_file: "RUNBOOK.md")
+
+          contents = File.read("RUNBOOK.md")
+          assert_match(/## \[Unreleased\]/, contents)
+          refute_match(/Old step/, contents)
+        end
+      end
+    end
+  end
+
+  describe ".deferred_finalize with runbook_file" do
+    it "stamps the runbook with the resolved version" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("CHANGELOG.md", <<~MD)
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            ## [Unreleased]
+
+            ### Added
+
+            - New feature
+          MD
+          File.write("RUNBOOK.md", <<~MD)
+            # Runbook
+
+            Steps to perform after releasing the version below.
+
+            ## [Unreleased]
+
+            - [ ] Manual step
+          MD
+
+          Reissue.deferred_finalize("2026-07-21", version: "2.0.0", changelog_file: "CHANGELOG.md", runbook_file: "RUNBOOK.md")
+
+          contents = File.read("RUNBOOK.md")
+          assert_match(/## \[2\.0\.0\] - 2026-07-21/, contents)
+          assert_match(/- \[ \] Manual step/, contents)
+        end
+      end
+    end
+  end
+
+  private
+
+  def setup_git_repo
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+    File.write("test.txt", "initial")
+    system("git add test.txt", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial commit'", out: File::NULL, err: File::NULL)
+  end
+
+  def create_tag(tag_name)
+    system("git tag -a #{tag_name} -m 'Release #{tag_name}'", out: File::NULL, err: File::NULL)
+  end
+
+  def create_commit(message)
+    filename = "file_#{Time.now.to_f}.txt"
+    File.write(filename, "content")
+    system("git add #{filename}", out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", message, out: File::NULL, err: File::NULL)
+  end
+end

--- a/test/test_runbook.rb
+++ b/test/test_runbook.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "reissue/runbook"
+
+class TestRunbook < Minitest::Spec
+  before do
+    @tempfile = Tempfile.new(["runbook", ".md"])
+    @runbook = Reissue::Runbook.new(@tempfile.path)
+  end
+
+  after do
+    @tempfile.close!
+  end
+
+  describe "generate" do
+    it "writes a header-only template for an unreleased version" do
+      @runbook.generate
+
+      contents = File.read(@tempfile.path)
+      assert_match(/# Runbook/, contents)
+      assert_match(/Steps to perform after releasing the version below\./, contents)
+      assert_match(/## \[Unreleased\]/, contents)
+      refute_match(/- \[ \]/, contents)
+    end
+  end
+
+  describe "clear" do
+    it "resets a finalized runbook to the unreleased template" do
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21", trailer_items: ["Run cleanup (abc1234)"])
+      @runbook.clear
+
+      contents = File.read(@tempfile.path)
+      assert_match(/## \[Unreleased\]/, contents)
+      refute_match(/1\.2\.3/, contents)
+      refute_match(/Run cleanup/, contents)
+    end
+  end
+
+  describe "items" do
+    it "returns an empty array for a header-only runbook" do
+      @runbook.generate
+
+      assert_empty @runbook.items
+    end
+
+    it "returns an empty array when the file does not exist" do
+      runbook = Reissue::Runbook.new(File.join(Dir.mktmpdir, "RUNBOOK.md"))
+
+      assert_empty runbook.items
+    end
+
+    it "parses unchecked, checked, and plain bullet items" do
+      File.write(@tempfile.path, <<~MD)
+        # Runbook
+
+        Steps to perform after releasing the version below.
+
+        ## [Unreleased]
+
+        - [ ] Run `rake data:cleanup`
+        - [x] Re-index search documents
+        - Notify the support team
+      MD
+
+      assert_equal [
+        "Run `rake data:cleanup`",
+        "Re-index search documents",
+        "Notify the support team"
+      ], @runbook.items
+    end
+  end
+
+  describe "finalize" do
+    it "stamps the header with the version and date" do
+      @runbook.generate
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21")
+
+      contents = File.read(@tempfile.path)
+      assert_match(/## \[1\.2\.3\] - 2026-07-21/, contents)
+      refute_match(/Unreleased/, contents)
+    end
+
+    it "writes trailer items as unchecked checklist entries" do
+      @runbook.generate
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21", trailer_items: ["Run cleanup (abc1234)"])
+
+      contents = File.read(@tempfile.path)
+      assert_match(/- \[ \] Run cleanup \(abc1234\)/, contents)
+    end
+
+    it "merges directly edited items with trailer items" do
+      File.write(@tempfile.path, <<~MD)
+        # Runbook
+
+        Steps to perform after releasing the version below.
+
+        ## [Unreleased]
+
+        - [ ] Manually added step
+      MD
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21", trailer_items: ["Run cleanup (abc1234)"])
+
+      contents = File.read(@tempfile.path)
+      assert_match(/- \[ \] Manually added step/, contents)
+      assert_match(/- \[ \] Run cleanup \(abc1234\)/, contents)
+    end
+
+    it "deduplicates items by text" do
+      File.write(@tempfile.path, <<~MD)
+        # Runbook
+
+        Steps to perform after releasing the version below.
+
+        ## [Unreleased]
+
+        - [ ] Run cleanup (abc1234)
+      MD
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21", trailer_items: ["Run cleanup (abc1234)"])
+
+      contents = File.read(@tempfile.path)
+      assert_equal 1, contents.scan("Run cleanup (abc1234)").count
+    end
+
+    it "preserves checked state of directly edited items" do
+      File.write(@tempfile.path, <<~MD)
+        # Runbook
+
+        Steps to perform after releasing the version below.
+
+        ## [Unreleased]
+
+        - [x] Already done step
+      MD
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21", trailer_items: ["Already done step"])
+
+      contents = File.read(@tempfile.path)
+      assert_match(/- \[x\] Already done step/, contents)
+      assert_equal 1, contents.scan("Already done step").count
+    end
+
+    it "is idempotent when run twice with the same trailer items" do
+      @runbook.generate
+      2.times do
+        @runbook.finalize(version: "1.2.3", date: "2026-07-21", trailer_items: ["Run cleanup (abc1234)"])
+      end
+
+      contents = File.read(@tempfile.path)
+      assert_equal 1, contents.scan("Run cleanup (abc1234)").count
+      assert_equal 1, contents.scan("## [1.2.3] - 2026-07-21").count
+    end
+
+    it "bootstraps a missing file" do
+      path = File.join(Dir.mktmpdir, "RUNBOOK.md")
+      runbook = Reissue::Runbook.new(path)
+      runbook.finalize(version: "1.2.3", date: "2026-07-21", trailer_items: ["Run cleanup (abc1234)"])
+
+      contents = File.read(path)
+      assert_match(/# Runbook/, contents)
+      assert_match(/## \[1\.2\.3\] - 2026-07-21/, contents)
+      assert_match(/- \[ \] Run cleanup \(abc1234\)/, contents)
+    end
+
+    it "stamps the header even with no items" do
+      @runbook.generate
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21")
+
+      contents = File.read(@tempfile.path)
+      assert_match(/## \[1\.2\.3\] - 2026-07-21/, contents)
+    end
+  end
+end


### PR DESCRIPTION
Applications using reissue often have manual steps that must happen after a release ships — running a rake task, cleaning up data, re-indexing — and those steps have no home in the release workflow today. This adds an optional `runbook_file` setting so they can be tracked alongside the changelog: collected from `Runbook:` git trailers or direct edits during development, stamped with the release version at finalize so the release tag carries the checklist, and cleared when work on the next version begins.

The runbook keeps only the latest release since prior runbooks remain reachable via release tags. Gems are unlikely to need this, so the option is off by default and nothing changes when it is unset.