### PR TITLE
Update actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -50,7 +50,7 @@ jobs:
           git config --global user.email "${{ inputs.git_user_email }}"
           git config --global user.name "${{ inputs.git_user_name }}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
@@ -96,7 +96,7 @@ jobs:
 
       - name: Configure trusted publishing credentials
         if: inputs.dry_run != true
-        uses: rubygems/configure-rubygems-credentials@v1.0.0
+        uses: rubygems/configure-rubygems-credentials@v2.1.0
 
       - name: Release gem to RubyGems
         if: inputs.dry_run != true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         version: ["3.4", "4.0"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.version }}
@@ -65,14 +65,14 @@ jobs:
           fi
       - name: Upload Coverage Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report-ruby-${{ matrix.version }}
           path: coverage/
           retention-days: 30
       - name: Comment Coverage on PR
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -134,7 +134,7 @@ jobs:
       matrix:
         version: ["3.4"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.version }}


### PR DESCRIPTION
GitHub is deprecating Node 20 on Actions runners, and the release workflow now emits a warning that `actions/checkout@v4` and `rubygems/configure-rubygems-credentials@v1.0.0` are being force-migrated to Node 24. Rather than rely on that fallback, this pins versions that declare `node24` themselves.

- `actions/checkout` v4 → v7
- `rubygems/configure-rubygems-credentials` v1.0.0 → v2.1.0
- `actions/upload-artifact` v4 → v7
- `actions/github-script` v7 → v9

`test.yml` is included because it has the same deprecated actions, just without a warning surfaced yet.

Breaking changes in these majors were checked against how we actually use them: checkout v7 blocks fork-PR checkout for `pull_request_target`/`workflow_run` (neither trigger is used here), and github-script v9 breaks `require('@actions/github')` in scripts (ours only requires `fs`).

One thing to note for downstream repos: these versions require Actions runner 2.327.1+. `shared-ruby-gem-release.yml` is consumed via `@main`, so anyone on self-hosted runners older than that will need to update.