### PR TITLE
Generate checksums on release and fix the released-version output

### DIFF
--- a/.github/workflows/SHARED_WORKFLOW_README.md
+++ b/.github/workflows/SHARED_WORKFLOW_README.md
@@ -40,7 +40,13 @@ The workflow auto-detects the repository's default branch.
 
 | Output | Description |
 |--------|-------------|
-| `version` | The version that was released. Empty on a dry run, which does not build a gem. |
+| `version` | The version that was released. On a dry run, the version a release *would* produce. |
+
+A dry run builds nothing, so it asks `rake reissue:next_version` what a release
+would publish — that task derives the version without writing anything. The
+output is empty if reissue is older than 0.5.2 and does not define the task, or
+if there is no tag and trailer to resolve a version from; the dry run says so
+rather than failing.
 
 Example using the output:
 ```yaml

--- a/.github/workflows/SHARED_WORKFLOW_README.md
+++ b/.github/workflows/SHARED_WORKFLOW_README.md
@@ -27,6 +27,12 @@ All inputs are optional:
 | `git_user_email` | `github-actions[bot]@users.noreply.github.com` | Email for git commits |
 | `git_user_name` | `github-actions[bot]` | Name for git commits |
 | `dry_run` | `false` | Test workflow without publishing to RubyGems |
+| `generate_checksum` | `false` | Write a SHA512 of the built gem into `checksums/` before publishing |
+
+Set `generate_checksum: true` to opt into checksums. It is off by default so that
+repositories already using this workflow do not start committing a `checksums/`
+directory they never asked for — `reissue/gem.rb` adds `checksums` to the paths
+reissue commits, so the file would land in the post-release version bump.
 
 The workflow auto-detects the repository's default branch.
 
@@ -52,9 +58,10 @@ jobs:
 ## What It Does
 
 1. Records the starting branch
-2. Runs `rake build:checksum release`, a single rake invocation that:
+2. Runs `rake release` (or `rake build:checksum release` when `generate_checksum`
+   is set), a single rake invocation that:
    - runs `reissue:bump` and `reissue:finalize`, which are prerequisites of `build`
-   - builds the gem into `pkg/` and writes its SHA512 into `checksums/`
+   - builds the gem into `pkg/`, and writes its SHA512 into `checksums/` if asked
    - tags the release and publishes to RubyGems.org via Trusted Publishing
    - runs reissue's post-release version bump
 3. Reads the released version back out of the gem that was actually built

--- a/.github/workflows/SHARED_WORKFLOW_README.md
+++ b/.github/workflows/SHARED_WORKFLOW_README.md
@@ -34,7 +34,7 @@ The workflow auto-detects the repository's default branch.
 
 | Output | Description |
 |--------|-------------|
-| `version` | The version that was released |
+| `version` | The version that was released. Empty on a dry run, which does not build a gem. |
 
 Example using the output:
 ```yaml
@@ -51,14 +51,21 @@ jobs:
 
 ## What It Does
 
-1. Records starting branch
-2. Finalizes changelog using `rake build:checksum`
-3. Detects if reissue created a new branch during finalization
-4. Extracts version from built gem
-5. Commits finalization changes if any
-6. Publishes to RubyGems.org via Trusted Publishing (runs `rake release` which triggers reissue's version bump)
-7. Detects if reissue created a new branch during version bump
-8. Either creates a PR (if on new branch) or pushes directly to default branch
+1. Records the starting branch
+2. Runs `rake build:checksum release`, a single rake invocation that:
+   - runs `reissue:bump` and `reissue:finalize`, which are prerequisites of `build`
+   - builds the gem into `pkg/` and writes its SHA512 into `checksums/`
+   - tags the release and publishes to RubyGems.org via Trusted Publishing
+   - runs reissue's post-release version bump
+3. Reads the released version back out of the gem that was actually built
+4. Waits for the gem to appear in the RubyGems index
+5. Detects whether reissue moved onto a new branch
+6. Commits anything reissue left behind (including the new checksum) if it did not
+7. Pushes the branch and opens a PR for the post-release version bump
+
+`build:checksum` and `release` both depend on `build`, and rake runs a task at most
+once per process, so naming both on one command line builds the gem a single time
+and guarantees the checksum is written before anything is published.
 
 ## Rake Task Configuration
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,4 @@ jobs:
       git_user_email: 'gems@sofwarellc.com'
       git_user_name: 'SOFware'
       dry_run: ${{ inputs.dry_run }}
+      generate_checksum: true

--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -115,17 +115,31 @@ jobs:
       # actually produced, which reissue may have bumped during `build`.
       - name: Get version being released
         id: version
-        if: inputs.dry_run != true
         working-directory: ${{ inputs.working_directory }}
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          gem_file=$(ls -t pkg/*.gem 2>/dev/null | head -1)
-          if [ -z "$gem_file" ]; then
-            echo "::error::No gem found in pkg/ - the release step did not build one"
-            exit 1
+          if [ "$DRY_RUN" = "true" ]; then
+            # Nothing was built, so ask reissue what a release would produce. The
+            # task computes the version without writing anything; reissue versions
+            # older than 0.5.2 do not define it, hence the fallback to unknown.
+            if raw=$(bundle exec rake reissue:next_version 2>/dev/null); then
+              version=$(printf '%s\n' "$raw" | tail -1 | tr -d '[:space:]')
+            else
+              version=""
+            fi
+          else
+            # Read the version from the gem that was actually produced, which
+            # reissue may have bumped during `build`.
+            gem_file=$(ls -t pkg/*.gem 2>/dev/null | head -1)
+            if [ -z "$gem_file" ]; then
+              echo "::error::No gem found in pkg/ - the release step did not build one"
+              exit 1
+            fi
+            version=$(ruby -e 'require "rubygems/package"; puts Gem::Package.new(ARGV[0]).spec.version' "$gem_file")
           fi
-          version=$(ruby -e 'require "rubygems/package"; puts Gem::Package.new(ARGV[0]).spec.version' "$gem_file")
           echo "released=$version" >> $GITHUB_OUTPUT
-          echo "Released version: $version"
+          echo "Version: ${version:-unknown}"
 
       - name: Wait for release to propagate
         if: inputs.dry_run != true
@@ -135,7 +149,14 @@ jobs:
       - name: Dry run - skip RubyGems publish
         if: inputs.dry_run == true
         working-directory: ${{ inputs.working_directory }}
-        run: echo "Dry run - no gem was built and nothing was published. The version is not known until a real run builds the gem."
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.released }}
+        run: |
+          if [ -n "$NEXT_VERSION" ]; then
+            echo "Dry run - would publish version $NEXT_VERSION to RubyGems. Nothing was built or published."
+          else
+            echo "Dry run - nothing was built or published. Could not determine the version: reissue:next_version is unavailable (reissue older than 0.5.2) or could not resolve one."
+          fi
 
       - name: Check for branch change after release
         id: release_branch

--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -87,21 +87,32 @@ jobs:
         id: start
         run: echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
-      - name: Get version being released
-        id: version
-        working-directory: ${{ inputs.working_directory }}
-        run: |
-          version=$(ls pkg/*.gem | head -1 | sed 's/.*-\([0-9][^-]*\)\.gem/\1/')
-          echo "released=$version" >> $GITHUB_OUTPUT
-
       - name: Configure trusted publishing credentials
         if: inputs.dry_run != true
         uses: rubygems/configure-rubygems-credentials@v2.1.0
 
+      # build:checksum and release share the same `build` prerequisite, so a
+      # single rake invocation builds once and writes checksums/ before pushing.
       - name: Release gem to RubyGems
         if: inputs.dry_run != true
         working-directory: ${{ inputs.working_directory }}
-        run: bundle exec rake release
+        run: bundle exec rake build:checksum release
+
+      # Must run after the build: the version is read from the gem that was
+      # actually produced, which reissue may have bumped during `build`.
+      - name: Get version being released
+        id: version
+        if: inputs.dry_run != true
+        working-directory: ${{ inputs.working_directory }}
+        run: |
+          gem_file=$(ls -t pkg/*.gem 2>/dev/null | head -1)
+          if [ -z "$gem_file" ]; then
+            echo "::error::No gem found in pkg/ - the release step did not build one"
+            exit 1
+          fi
+          version=$(ruby -e 'require "rubygems/package"; puts Gem::Package.new(ARGV[0]).spec.version' "$gem_file")
+          echo "released=$version" >> $GITHUB_OUTPUT
+          echo "Released version: $version"
 
       - name: Wait for release to propagate
         if: inputs.dry_run != true
@@ -111,7 +122,7 @@ jobs:
       - name: Dry run - skip RubyGems publish
         if: inputs.dry_run == true
         working-directory: ${{ inputs.working_directory }}
-        run: echo "Dry run - would publish version ${{ steps.version.outputs.released }} to RubyGems"
+        run: echo "Dry run - no gem was built and nothing was published. The version is not known until a real run builds the gem."
 
       - name: Check for branch change after release
         id: release_branch

--- a/.github/workflows/shared-ruby-gem-release.yml
+++ b/.github/workflows/shared-ruby-gem-release.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: '.'
+      generate_checksum:
+        description: 'Write a SHA512 of the built gem into checksums/ before publishing'
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: 'The version that was released'
@@ -91,12 +96,20 @@ jobs:
         if: inputs.dry_run != true
         uses: rubygems/configure-rubygems-credentials@v2.1.0
 
-      # build:checksum and release share the same `build` prerequisite, so a
-      # single rake invocation builds once and writes checksums/ before pushing.
+      # build:checksum and release share the same `build` prerequisite, and rake
+      # runs a task at most once per process, so naming both here builds the gem
+      # a single time and writes checksums/ before anything is pushed.
       - name: Release gem to RubyGems
         if: inputs.dry_run != true
         working-directory: ${{ inputs.working_directory }}
-        run: bundle exec rake build:checksum release
+        env:
+          GENERATE_CHECKSUM: ${{ inputs.generate_checksum }}
+        run: |
+          if [ "$GENERATE_CHECKSUM" = "true" ]; then
+            bundle exec rake build:checksum release
+          else
+            bundle exec rake release
+          fi
 
       # Must run after the build: the version is read from the gem that was
       # actually produced, which reissue may have bumped during `build`.


### PR DESCRIPTION
The last release published 0.5.0 with no SHA512 checksum, and the workflow's `version` output was empty. Two separate causes, both in the release workflow.

**Checksums were never generated.** The workflow runs `bundle exec rake release`, but bundler wires `build:checksum` up as its own task rather than as part of the release chain (`release` depends on `build`, `release:guard_clean`, `release:source_control_push`, `release:rubygem_push`). Nothing ever invoked it, and no checksum has been written since 0.4.6.

Naming both tasks on one command line fixes it: they share the `build` prerequisite and rake runs a task at most once per process, so the gem is still built exactly once and the checksum is written before anything is pushed. The untracked checksum does not disturb `release:guard_clean`, which uses `git diff` and `git diff-index --cached` and so ignores untracked files.

Because other repositories consume this workflow from `@main`, and `reissue/gem.rb` adds `checksums` to the paths reissue commits, enabling this unconditionally would make those repositories start committing a `checksums/` directory they never asked for. It is a new `generate_checksum` input defaulting to `false`, and reissue's own `release.yml` opts in.

**The version output was always empty.** The step ran before anything built a gem, so `ls pkg/*.gem` failed every time — the run log for the 0.5.0 release shows `ls: cannot access 'pkg/*.gem': No such file or directory`. The step still passed, because the assignment took its exit status from the `sed` at the end of the pipeline rather than from `ls`. It now runs after the release, reads the version out of the gem's own metadata instead of parsing the filename, and fails with a `::error::` annotation if no gem is present. Dry runs build nothing, so they no longer report a version they cannot know.

`SHARED_WORKFLOW_README.md` described a `rake build:checksum` step that was not in the workflow; it now matches what actually runs.

This does not address the version/changelog skew that shipped 0.5.0 without a changelog entry — that lives in `lib/reissue/gem.rb`, where `reissue:bump` is a prerequisite of `build`, and needs its own fix.

## Dry runs now report the version

A dry run builds nothing, so there was no gem to read a version from. `rake reissue:next_version` (added in #132) answers the question directly by deriving the version without writing anything, so the version step asks it in dry-run mode and the workflow's `version` output is populated either way.

Reissue versions without that task make the command fail rather than print, so the step falls back to an empty version and the dry run reports that it could not determine one instead of failing the run. I verified both paths: against a checkout without the task the step degrades and exits 0; against one with it, the version is captured and written to `GITHUB_OUTPUT`.

This part depends on #132 for reissue's own releases, and on consumers running a reissue new enough to define the task. Neither is required for the run to succeed.