### PR TITLE
Add reissue:next_version to report the version a release would use

### DIFF
--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -188,6 +188,43 @@ module Reissue
       end
     end
 
+    # The version the next release would use, derived exactly the way reissue:bump
+    # derives it, without writing anything.
+    #
+    # @return [Gem::Version] the version a release would publish
+    def next_release_version
+      require_relative "fragment_handler"
+      require_relative "version_updater"
+
+      # reissue:bump only consults git trailers for :git fragments.
+      handler = (Reissue::FragmentHandler.for(:git, tag_pattern: tag_pattern) if fragment == :git)
+      tag_version = handler&.last_tag_version
+      bump = handler&.read_version_bump
+      updater = Reissue::VersionUpdater.new(version_file, version_redo_proc: version_redo_proc)
+
+      if deferred_versioning
+        # The version file holds "Unreleased"; finalize resolves the real version
+        # from the last tag and the trailer.
+        unless tag_version && bump
+          raise "Cannot determine the next version. Deferred versioning resolves it from " \
+                "the last version tag and a Version: trailer, and one of those is missing."
+        end
+        return updater.redo(tag_version, bump)
+      end
+
+      current_version = ::Gem::Version.new(File.read(version_file).match(Reissue::VersionUpdater::VERSION_MATCH)[0])
+
+      if bump.nil?
+        current_version
+      elsif tag_version && tag_version != current_version
+        # A post-release bump already moved the file past the tag, so the trailer
+        # only counts if it would land beyond where the file already is.
+        [updater.redo(tag_version, bump), current_version].max
+      else
+        updater.redo(current_version, bump)
+      end
+    end
+
     # Check if there are staged changes ready to commit.
     def changes_to_commit?
       _, _, status = Open3.capture3("git diff --cached --quiet")
@@ -359,6 +396,15 @@ module Reissue
             end
           end
 
+          # Preview reports; it does not fail. next_release_version raises when
+          # deferred versioning has no tag or trailer to resolve from.
+          previewed_version = begin
+            next_release_version
+          rescue RuntimeError
+            nil
+          end
+          puts "Version to be released: #{previewed_version || "cannot be determined"}\n\n"
+
           entries = handler.read
 
           if entries.empty?
@@ -416,6 +462,11 @@ module Reissue
             puts clear_message
           end
         end
+      end
+
+      desc "Print the version the next release would use, without changing anything"
+      task "#{name}:next_version" do
+        puts next_release_version
       end
 
       desc "Bump version based on git trailers"

--- a/test/test_rake_next_version_task.rb
+++ b/test/test_rake_next_version_task.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+require "stringio"
+require "tempfile"
+require "tmpdir"
+
+class TestRakeNextVersionTask < Minitest::Test
+  def setup
+    @rake = Rake::Application.new
+    Rake.application = @rake
+  end
+
+  def teardown
+    Rake.application.clear
+  end
+
+  def test_reports_version_the_minor_trailer_would_produce
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.3")
+        create_commit_with_trailer("New feature", "Version: minor")
+
+        create_rakefile
+        load "Rakefile"
+
+        output, _err = capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        assert_equal "1.3.0", output.strip
+      end
+    end
+  end
+
+  def test_reports_current_version_when_no_version_trailer_is_present
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.3")
+        create_commit_with_trailer("Regular fix", "Fixed: Some bug")
+
+        create_rakefile
+        load "Rakefile"
+
+        output, _err = capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        assert_equal "1.2.3", output.strip
+      end
+    end
+  end
+
+  # Mirrors reissue:bump, which derives the bump from the last tag and skips when
+  # that lands at or below the version already in the file.
+  def test_reports_current_version_when_the_trailer_would_not_advance_past_it
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.2")
+        bump_version_file_to("1.2.3")
+        create_commit_with_trailer("Bug fix", "Version: patch")
+
+        create_rakefile
+        load "Rakefile"
+
+        output, _err = capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        # patch(v1.2.2) is 1.2.3, which the file already holds, so nothing moves
+        assert_equal "1.2.3", output.strip
+      end
+    end
+  end
+
+  def test_derives_the_bump_from_the_last_tag_rather_than_the_version_file
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.2")
+        bump_version_file_to("1.5.0")
+        create_commit_with_trailer("New feature", "Version: minor")
+
+        create_rakefile
+        load "Rakefile"
+
+        output, _err = capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        # minor(v1.2.2) is 1.3.0, behind the file's 1.5.0, so the file wins
+        assert_equal "1.5.0", output.strip
+      end
+    end
+  end
+
+  def test_leaves_the_version_file_and_working_tree_untouched
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.3")
+        create_commit_with_trailer("New feature", "Version: minor")
+
+        create_rakefile
+        load "Rakefile"
+
+        before = File.read("version.rb")
+        status_before = `git status --porcelain`
+
+        capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        assert_equal before, File.read("version.rb"), "next_version must not rewrite the version file"
+        assert_equal status_before, `git status --porcelain`, "next_version must not alter the working tree"
+      end
+    end
+  end
+
+  def test_leaves_the_version_file_untouched_when_the_file_is_ahead_of_the_tag
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.2")
+        bump_version_file_to("1.2.3")
+        create_commit_with_trailer("New feature", "Version: minor")
+
+        create_rakefile
+        load "Rakefile"
+
+        before = File.read("version.rb")
+        status_before = `git status --porcelain`
+
+        capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        assert_equal before, File.read("version.rb"), "next_version must not rewrite the version file"
+        assert_equal status_before, `git status --porcelain`, "next_version must not alter the working tree"
+      end
+    end
+  end
+
+  # reissue:bump exits early unless fragment is :git, so git trailers cannot move
+  # the version for a directory-fragment project and must not be reported as if
+  # they would.
+  def test_ignores_git_trailers_when_fragments_come_from_a_directory
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.3")
+        create_commit_with_trailer("New feature", "Version: minor")
+
+        create_rakefile_with_directory_fragments
+        load "Rakefile"
+
+        output, _err = capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        assert_equal "1.2.3", output.strip
+      end
+    end
+  end
+
+  # Under deferred versioning the version file holds "Unreleased" and the real
+  # version is resolved at finalize time from the last tag plus the trailer.
+  def test_resolves_from_the_tag_when_versioning_is_deferred
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.2")
+        bump_version_file_to("Unreleased")
+        create_commit_with_trailer("New feature", "Version: minor")
+
+        create_rakefile_with_deferred_versioning
+        load "Rakefile"
+
+        output, _err = capture_io { Rake::Task["reissue:next_version"].invoke }
+
+        assert_equal "1.3.0", output.strip
+      end
+    end
+  end
+
+  def test_explains_itself_when_deferred_versioning_has_nothing_to_resolve_from
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_git_repo_with_version("1.2.2")
+        bump_version_file_to("Unreleased")
+        create_commit_with_trailer("Regular fix", "Fixed: Some bug")
+
+        create_rakefile_with_deferred_versioning
+        load "Rakefile"
+
+        error = assert_raises(RuntimeError) do
+          capture_io { Rake::Task["reissue:next_version"].invoke }
+        end
+
+        assert_match(/cannot determine the next version/i, error.message)
+      end
+    end
+  end
+
+  private
+
+  def create_rakefile_with_deferred_versioning
+    File.write("Rakefile", <<~RUBY)
+      require "reissue/rake"
+
+      Reissue::Task.create :reissue do |task|
+        task.version_file = "version.rb"
+        task.fragment = :git
+        task.deferred_versioning = true
+      end
+    RUBY
+  end
+
+  def create_rakefile_with_directory_fragments
+    Dir.mkdir("changelog_fragments")
+    File.write("Rakefile", <<~RUBY)
+      require "reissue/rake"
+
+      Reissue::Task.create :reissue do |task|
+        task.version_file = "version.rb"
+        task.fragment = "changelog_fragments"
+      end
+    RUBY
+  end
+
+  def bump_version_file_to(version)
+    File.write("version.rb", "VERSION = \"#{version}\"")
+    system("git add version.rb", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Bump version to #{version}'", out: File::NULL, err: File::NULL)
+  end
+
+  def setup_git_repo_with_version(version)
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+    File.write("version.rb", "VERSION = \"#{version}\"")
+    system("git add version.rb", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial version'", out: File::NULL, err: File::NULL)
+    system("git tag v#{version}", out: File::NULL, err: File::NULL)
+  end
+
+  def create_commit_with_trailer(subject, trailer)
+    filename = "test_#{Time.now.to_f}.txt"
+    File.write(filename, "content")
+    system("git add #{filename}", out: File::NULL, err: File::NULL)
+
+    message = "#{subject}\n\n#{trailer}"
+    Tempfile.create("commit_msg") do |f|
+      f.write(message)
+      f.flush
+      system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
+    end
+  end
+
+  def create_rakefile
+    File.write("Rakefile", <<~RUBY)
+      require "reissue/rake"
+
+      Reissue::Task.create :reissue do |task|
+        task.version_file = "version.rb"
+        task.fragment = :git
+      end
+    RUBY
+  end
+end

--- a/test/test_rake_preview_task.rb
+++ b/test/test_rake_preview_task.rb
@@ -126,6 +126,75 @@ class TestRakePreviewTask < Minitest::Test
     end
   end
 
+  def test_preview_reports_the_version_that_would_be_released
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        system("git init", out: File::NULL, err: File::NULL)
+        system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+        system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+        File.write("test.txt", "initial")
+        system("git add test.txt", out: File::NULL, err: File::NULL)
+        system("git commit -m 'Initial'", out: File::NULL, err: File::NULL)
+        system("git tag v1.0.0", out: File::NULL, err: File::NULL)
+
+        create_commit_with_trailer("Feature", "Added: New feature\n\nVersion: minor")
+
+        File.write("Rakefile", <<~RUBY)
+          require "reissue/rake"
+
+          Reissue::Task.create :reissue do |task|
+            task.version_file = "version.rb"
+            task.fragment = :git
+          end
+        RUBY
+
+        File.write("version.rb", 'VERSION = "1.0.0"')
+
+        load "Rakefile"
+        result, _err = capture_io { Rake::Task["reissue:preview"].invoke }
+
+        assert_match(/Version to be released: 1\.1\.0/, result)
+      end
+    end
+  end
+
+  def test_preview_still_runs_when_the_version_cannot_be_determined
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        system("git init", out: File::NULL, err: File::NULL)
+        system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+        system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+        File.write("test.txt", "initial")
+        system("git add test.txt", out: File::NULL, err: File::NULL)
+        system("git commit -m 'Initial'", out: File::NULL, err: File::NULL)
+        system("git tag v1.0.0", out: File::NULL, err: File::NULL)
+
+        create_commit_with_trailer("Feature", "Added: New feature")
+
+        File.write("Rakefile", <<~RUBY)
+          require "reissue/rake"
+
+          Reissue::Task.create :reissue do |task|
+            task.version_file = "version.rb"
+            task.fragment = :git
+            task.deferred_versioning = true
+          end
+        RUBY
+
+        File.write("version.rb", 'VERSION = "Unreleased"')
+
+        load "Rakefile"
+        result, _err = capture_io { Rake::Task["reissue:preview"].invoke }
+
+        # Preview is a reporting tool; it should say so rather than raise
+        assert_match(/Version to be released: cannot be determined/, result)
+        assert_match(/- New feature/, result)
+      end
+    end
+  end
+
   private
 
   def create_commit_with_trailer(subject, trailer)


### PR DESCRIPTION
There was no way to ask what a release would produce without producing it. `reissue:bump` knows the answer, but only by writing it to the version file, so a dry run had nothing to report — which is why the release workflow's dry run currently cannot name a version.

`next_release_version` derives the same answer and writes nothing. Where `reissue:bump` calls `VersionUpdater#call`, this calls `#redo`, which computes the version without touching the file. `reissue:next_version` prints just the bare version so a script can capture it directly, and `reissue:preview` now reports it alongside the changelog entries it already showed.

## Matching reissue:bump

The value is only useful if it agrees with what a release actually does, so it mirrors every branch of `reissue:bump`, including the ones that decline to move:

- git trailers are ignored unless `fragment` is `:git`, because `reissue:bump` exits early otherwise
- the bump is derived from the last tag, not the version file
- a version already ahead of what the trailer would produce wins, matching bump's "already bumped, skipping"
- under deferred versioning the file holds `"Unreleased"`, so the version resolves from the tag the way `deferred_finalize` resolves it

Worth noting what it reports for the state this repository was in before the last release: a `Version: minor` trailer against tag `v0.4.23` gives **0.5.0** — the version that release actually published while the tag and changelog both said 0.4.23. A dry run would have shown that skew before it shipped.

## Tests

Nine tests for the new task and two for preview, written first and each watched fail. Two of them assert the task leaves the version file and working tree untouched, which is the property the whole thing rests on. I verified those tests can actually catch a regression by temporarily swapping `#redo` for `#call` and confirming they fail — the first attempt at that sabotage passed, which revealed the tag-differs branch had no side-effect coverage, so it now has its own test.

Preview reports an undeterminable version as "cannot be determined" rather than raising, since it exists to describe the state rather than gate on it.

Full suite: 203 runs, 638 assertions, 0 failures.

I left `Version: minor` off this commit's trailers deliberately. It is the semantically correct trailer for a new feature, but it would trip the `lib/reissue/gem.rb` ordering bug on the next release — the same one that shipped 0.5.0 as `v0.4.23`. Worth adding once that is fixed.