### PR TITLE
Keep the released version, changelog entry, and tag in agreement

### DIFF
--- a/lib/reissue/gem.rb
+++ b/lib/reissue/gem.rb
@@ -7,6 +7,30 @@ module Reissue
       super
       @updated_paths << "checksums"
     end
+
+    # Keep bundler's gemspec in step with the bump.
+    #
+    # Bundler loads the gemspec when bundler/gem_tasks is required, well before
+    # reissue:bump rewrites the version file. `gem build` shells out and re-reads
+    # the file, so the gem itself carries the bumped version, but the release tag
+    # and bundler's confirmation messages read the copy held in memory. Without
+    # this they name the version from before the bump, and the release publishes
+    # one version under another version's tag.
+    def apply_version_bump(updater, bump)
+      new_version = super
+      sync_bundler_gemspec_version(new_version)
+      new_version
+    end
+
+    # @param new_version [String] the version the bump landed on
+    def sync_bundler_gemspec_version(new_version)
+      return unless defined?(Bundler::GemHelper)
+
+      helper = Bundler::GemHelper.instance
+      return unless helper.respond_to?(:gemspec) && helper.gemspec
+
+      helper.gemspec.version = ::Gem::Version.new(new_version)
+    end
   end
 end
 Reissue::Task.prepend Reissue::Gem

--- a/lib/reissue/gem.rb
+++ b/lib/reissue/gem.rb
@@ -27,7 +27,7 @@ module Reissue
       return unless defined?(Bundler::GemHelper)
 
       helper = Bundler::GemHelper.instance
-      return unless helper.respond_to?(:gemspec) && helper.gemspec
+      return unless helper&.gemspec
 
       helper.gemspec.version = ::Gem::Version.new(new_version)
     end

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -225,6 +225,41 @@ module Reissue
       end
     end
 
+    # Apply a version bump and leave the changelog agreeing with it.
+    #
+    # @param updater [Reissue::VersionUpdater] the updater to bump with
+    # @param bump [Symbol] the segment to bump
+    # @return [String] the version the bump landed on
+    def apply_version_bump(updater, bump)
+      new_version = updater.call(bump)
+      realign_unreleased_changelog(new_version)
+      bundle
+      puts "Version bumped (#{bump}) to #{new_version}"
+      new_version
+    end
+
+    # Point the changelog's unreleased entry at the version just bumped to.
+    #
+    # The bump moves the version file forward, but the unreleased entry still
+    # carries the number from the previous cycle. reissue:finalize dates whatever
+    # that entry says, so leaving it alone publishes a gem built at the new
+    # version while the only dated changelog entry names the old one.
+    #
+    # @param new_version [String] the version the bump landed on
+    def realign_unreleased_changelog(new_version)
+      return unless changelog_file && File.exist?(changelog_file)
+
+      changelog = Reissue::Parser.parse(File.read(changelog_file))
+      unreleased = changelog["versions"].find { |version| version["date"] == "Unreleased" }
+      return if unreleased.nil? || unreleased["version"] == new_version
+
+      unreleased["version"] = new_version
+
+      changelog_updater = Reissue::ChangelogUpdater.new(changelog_file)
+      changelog_updater.instance_variable_set(:@changelog, changelog)
+      changelog_updater.write(changelog_file)
+    end
+
     # Check if there are staged changes ready to commit.
     def changes_to_commit?
       _, _, status = Open3.capture3("git diff --cached --quiet")
@@ -492,9 +527,7 @@ module Reissue
         if tag_version && current_version == tag_version
           if bump
             updater = Reissue::VersionUpdater.new(version_file, version_redo_proc: version_redo_proc)
-            updater.call(bump)
-            bundle
-            puts "Version bumped (#{bump}) to #{updater.instance_variable_get(:@new_version)}"
+            apply_version_bump(updater, bump)
           end
         elsif tag_version && current_version != tag_version
           if bump
@@ -502,9 +535,7 @@ module Reissue
             desired_version = updater.redo(tag_version, bump)
 
             if desired_version > current_version
-              updater.call(bump)
-              bundle
-              puts "Version bumped (#{bump}) to #{updater.instance_variable_get(:@new_version)}"
+              apply_version_bump(updater, bump)
             else
               puts "Version already bumped (#{tag_version} → #{current_version}), skipping"
             end
@@ -513,9 +544,7 @@ module Reissue
           end
         elsif bump
           updater = Reissue::VersionUpdater.new(version_file, version_redo_proc: version_redo_proc)
-          updater.call(bump)
-          bundle
-          puts "Version bumped (#{bump}) to #{updater.instance_variable_get(:@new_version)}"
+          apply_version_bump(updater, bump)
         end
       end
     end

--- a/test/support/git_repo_helpers.rb
+++ b/test/support/git_repo_helpers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+module GitRepoHelpers
+  def init_git_repo
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+  end
+
+  def commit_everything(message)
+    system("git add .", out: File::NULL, err: File::NULL)
+    system("git commit -m '#{message}'", out: File::NULL, err: File::NULL)
+  end
+
+  def tag_version(version)
+    system("git tag v#{version}", out: File::NULL, err: File::NULL)
+  end
+
+  def create_commit_with_trailer(subject, trailer)
+    filename = "test_#{Time.now.to_f}.txt"
+    File.write(filename, "content")
+    system("git add #{filename}", out: File::NULL, err: File::NULL)
+
+    Tempfile.create("commit_msg") do |f|
+      f.write("#{subject}\n\n#{trailer}")
+      f.flush
+      system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
+    end
+  end
+end

--- a/test/test_build_version_agreement.rb
+++ b/test/test_build_version_agreement.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "rake"
 require "stringio"
-require "tempfile"
 require "tmpdir"
 
 # The build task runs reissue:bump then reissue:finalize. Whatever version the
@@ -11,6 +10,8 @@ require "tmpdir"
 # finalized alongside it has to carry that same version. When they disagree the
 # release publishes a version with no changelog entry of its own.
 class TestBuildVersionAgreement < Minitest::Test
+  include GitRepoHelpers
+
   def setup
     @rake = Rake::Application.new
     Rake.application = @rake
@@ -48,9 +49,7 @@ class TestBuildVersionAgreement < Minitest::Test
   private
 
   def setup_project(version:)
-    system("git init", out: File::NULL, err: File::NULL)
-    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
-    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+    init_git_repo
 
     File.write("version.rb", "VERSION = \"#{version}\"\nRELEASE_DATE = \"Unreleased\"\n")
     File.write("CHANGELOG.md", <<~CHANGELOG)
@@ -65,21 +64,8 @@ class TestBuildVersionAgreement < Minitest::Test
       - Something earlier
     CHANGELOG
 
-    system("git add .", out: File::NULL, err: File::NULL)
-    system("git commit -m 'Initial'", out: File::NULL, err: File::NULL)
-    system("git tag v#{version}", out: File::NULL, err: File::NULL)
-  end
-
-  def create_commit_with_trailer(subject, trailer)
-    filename = "test_#{Time.now.to_f}.txt"
-    File.write(filename, "content")
-    system("git add #{filename}", out: File::NULL, err: File::NULL)
-
-    Tempfile.create("commit_msg") do |f|
-      f.write("#{subject}\n\n#{trailer}")
-      f.flush
-      system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
-    end
+    commit_everything("Initial")
+    tag_version(version)
   end
 
   def create_rakefile

--- a/test/test_build_version_agreement.rb
+++ b/test/test_build_version_agreement.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+require "stringio"
+require "tempfile"
+require "tmpdir"
+
+# The build task runs reissue:bump then reissue:finalize. Whatever version the
+# bump lands on is the version the gem will be built as, so the changelog entry
+# finalized alongside it has to carry that same version. When they disagree the
+# release publishes a version with no changelog entry of its own.
+class TestBuildVersionAgreement < Minitest::Test
+  def setup
+    @rake = Rake::Application.new
+    Rake.application = @rake
+  end
+
+  def teardown
+    Rake.application.clear
+  end
+
+  def test_finalized_changelog_entry_carries_the_bumped_version
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_project(version: "1.2.3")
+        create_commit_with_trailer("New feature", "Added: A thing\n\nVersion: minor")
+
+        create_rakefile
+        load "Rakefile"
+
+        capture_io do
+          Rake::Task["reissue:bump"].invoke
+          Rake::Task["reissue:finalize"].invoke
+        end
+
+        assert_match(/VERSION = "1.3.0"/, File.read("version.rb"))
+
+        changelog = File.read("CHANGELOG.md")
+        assert_match(/## \[1\.3\.0\] - \d{4}-\d{2}-\d{2}/, changelog,
+          "the released version must have a dated changelog entry")
+        refute_match(/## \[1\.2\.3\] - \d{4}-\d{2}-\d{2}/, changelog,
+          "the previous version must not be dated as if it were this release")
+      end
+    end
+  end
+
+  private
+
+  def setup_project(version:)
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+    File.write("version.rb", "VERSION = \"#{version}\"\nRELEASE_DATE = \"Unreleased\"\n")
+    File.write("CHANGELOG.md", <<~CHANGELOG)
+      # Changelog
+
+      ## [#{version}] - Unreleased
+
+      ## [1.2.2] - 2026-01-01
+
+      ### Added
+
+      - Something earlier
+    CHANGELOG
+
+    system("git add .", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial'", out: File::NULL, err: File::NULL)
+    system("git tag v#{version}", out: File::NULL, err: File::NULL)
+  end
+
+  def create_commit_with_trailer(subject, trailer)
+    filename = "test_#{Time.now.to_f}.txt"
+    File.write(filename, "content")
+    system("git add #{filename}", out: File::NULL, err: File::NULL)
+
+    Tempfile.create("commit_msg") do |f|
+      f.write("#{subject}\n\n#{trailer}")
+      f.flush
+      system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
+    end
+  end
+
+  def create_rakefile
+    File.write("Rakefile", <<~RUBY)
+      require "reissue/rake"
+
+      Reissue::Task.create :reissue do |task|
+        task.version_file = "version.rb"
+        task.fragment = :git
+        task.commit_finalize = false
+      end
+    RUBY
+  end
+end

--- a/test/test_gem_integration.rb
+++ b/test/test_gem_integration.rb
@@ -5,6 +5,8 @@ require "rake"
 require "tmpdir"
 
 class TestGemIntegration < Minitest::Test
+  include GitRepoHelpers
+
   def setup
     @rake = Rake::Application.new
     Rake.application = @rake
@@ -88,9 +90,7 @@ class TestGemIntegration < Minitest::Test
   private
 
   def setup_git_repo(version)
-    system("git init", out: File::NULL, err: File::NULL)
-    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
-    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+    init_git_repo
 
     File.write("version.rb", "VERSION = \"#{version}\"")
     File.write("CHANGELOG.md", <<~CHANGELOG)
@@ -103,8 +103,7 @@ class TestGemIntegration < Minitest::Test
       - Initial release
     CHANGELOG
 
-    system("git add .", out: File::NULL, err: File::NULL)
-    system("git commit -m 'Initial commit'", out: File::NULL, err: File::NULL)
+    commit_everything("Initial commit")
     system("git branch -M main", out: File::NULL, err: File::NULL)
   end
 end

--- a/test/test_gem_version_tag_agreement.rb
+++ b/test/test_gem_version_tag_agreement.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "rake"
 require "stringio"
-require "tempfile"
 require "tmpdir"
 
 # Bundler loads the gemspec once, when bundler/gem_tasks is required, which is
@@ -12,6 +11,8 @@ require "tmpdir"
 # confirmation messages come from the copy bundler is still holding. Left alone
 # they name the version before the bump.
 class TestGemVersionTagAgreement < Minitest::Test
+  include GitRepoHelpers
+
   def setup
     @rake = Rake::Application.new
     Rake.application = @rake
@@ -47,9 +48,7 @@ class TestGemVersionTagAgreement < Minitest::Test
   private
 
   def setup_project(version:)
-    system("git init", out: File::NULL, err: File::NULL)
-    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
-    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+    init_git_repo
 
     File.write("version.rb", "VERSION = \"#{version}\"\nRELEASE_DATE = \"Unreleased\"\n")
     File.write("CHANGELOG.md", <<~CHANGELOG)
@@ -76,21 +75,8 @@ class TestGemVersionTagAgreement < Minitest::Test
       end
     RUBY
 
-    system("git add .", out: File::NULL, err: File::NULL)
-    system("git commit -m 'Initial'", out: File::NULL, err: File::NULL)
-    system("git tag v#{version}", out: File::NULL, err: File::NULL)
-  end
-
-  def create_commit_with_trailer(subject, trailer)
-    filename = "test_#{Time.now.to_f}.txt"
-    File.write(filename, "content")
-    system("git add #{filename}", out: File::NULL, err: File::NULL)
-
-    Tempfile.create("commit_msg") do |f|
-      f.write("#{subject}\n\n#{trailer}")
-      f.flush
-      system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
-    end
+    commit_everything("Initial")
+    tag_version(version)
   end
 
   def create_rakefile

--- a/test/test_gem_version_tag_agreement.rb
+++ b/test/test_gem_version_tag_agreement.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+require "stringio"
+require "tempfile"
+require "tmpdir"
+
+# Bundler loads the gemspec once, when bundler/gem_tasks is required, which is
+# before reissue:bump rewrites the version file. `gem build` shells out and so
+# re-reads the file, producing a gem at the bumped version, but the tag and the
+# confirmation messages come from the copy bundler is still holding. Left alone
+# they name the version before the bump.
+class TestGemVersionTagAgreement < Minitest::Test
+  def setup
+    @rake = Rake::Application.new
+    Rake.application = @rake
+  end
+
+  def teardown
+    Rake.application.clear
+  end
+
+  def test_bundler_tags_the_version_the_bump_landed_on
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        setup_project(version: "1.2.3")
+        create_commit_with_trailer("New feature", "Added: A thing\n\nVersion: minor")
+
+        create_rakefile
+        load "Rakefile"
+
+        capture_io { Rake::Task["reissue:bump"].invoke }
+
+        assert_match(/VERSION = "1.3.0"/, File.read("version.rb"))
+
+        helper = Bundler::GemHelper.instance
+        assert_equal "1.3.0", helper.gemspec.version.to_s,
+          "bundler must hold the bumped version, not the one it cached at load"
+        # version_tag is protected; it is what release:source_control_push pushes
+        assert_equal "v1.3.0", helper.send(:version_tag),
+          "the release tag must name the version being published"
+      end
+    end
+  end
+
+  private
+
+  def setup_project(version:)
+    system("git init", out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+
+    File.write("version.rb", "VERSION = \"#{version}\"\nRELEASE_DATE = \"Unreleased\"\n")
+    File.write("CHANGELOG.md", <<~CHANGELOG)
+      # Changelog
+
+      ## [#{version}] - Unreleased
+
+      ## [1.2.2] - 2026-01-01
+
+      ### Added
+
+      - Something earlier
+    CHANGELOG
+
+    # A gemspec that reads its version from the file reissue rewrites, the way a
+    # real gem does.
+    File.write("demo.gemspec", <<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = "demo"
+        spec.version = File.read(File.expand_path("version.rb", __dir__))[/VERSION = "([^"]+)"/, 1]
+        spec.authors = ["Test"]
+        spec.summary = "Demo"
+        spec.files = []
+      end
+    RUBY
+
+    system("git add .", out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial'", out: File::NULL, err: File::NULL)
+    system("git tag v#{version}", out: File::NULL, err: File::NULL)
+  end
+
+  def create_commit_with_trailer(subject, trailer)
+    filename = "test_#{Time.now.to_f}.txt"
+    File.write(filename, "content")
+    system("git add #{filename}", out: File::NULL, err: File::NULL)
+
+    Tempfile.create("commit_msg") do |f|
+      f.write("#{subject}\n\n#{trailer}")
+      f.flush
+      system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
+    end
+  end
+
+  def create_rakefile
+    File.write("Rakefile", <<~RUBY)
+      require "bundler/gem_tasks"
+      require "reissue/gem"
+
+      Reissue::Task.create :reissue do |task|
+        task.version_file = "version.rb"
+        task.fragment = :git
+        task.commit_finalize = false
+      end
+    RUBY
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,3 +10,5 @@ require "debug"
 require "date"
 
 require "minitest/autorun"
+
+require_relative "support/git_repo_helpers"

--- a/test/test_rake_version_bump_task.rb
+++ b/test/test_rake_version_bump_task.rb
@@ -6,6 +6,8 @@ require "stringio"
 require "tmpdir"
 
 class TestRakeVersionBumpTask < Minitest::Test
+  include GitRepoHelpers
+
   def setup
     @rake = Rake::Application.new
     Rake.application = @rake
@@ -187,9 +189,7 @@ class TestRakeVersionBumpTask < Minitest::Test
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         # Setup git repo WITHOUT a tag
-        system("git init", out: File::NULL, err: File::NULL)
-        system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
-        system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+        init_git_repo
 
         # Create initial version file
         File.write("version.rb", 'VERSION = "0.1.0"')
@@ -323,28 +323,11 @@ class TestRakeVersionBumpTask < Minitest::Test
   private
 
   def setup_git_repo_with_version(version)
-    system("git init", out: File::NULL, err: File::NULL)
-    system("git config user.name 'Test'", out: File::NULL, err: File::NULL)
-    system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
+    init_git_repo
 
-    # Create initial version file and tag
     File.write("version.rb", "VERSION = \"#{version}\"")
-    system("git add version.rb", out: File::NULL, err: File::NULL)
-    system("git commit -m 'Initial version'", out: File::NULL, err: File::NULL)
-    system("git tag v#{version}", out: File::NULL, err: File::NULL)
-  end
-
-  def create_commit_with_trailer(subject, trailer)
-    filename = "test_#{Time.now.to_f}.txt"
-    File.write(filename, "content")
-    system("git add #{filename}", out: File::NULL, err: File::NULL)
-
-    message = "#{subject}\n\n#{trailer}"
-    Tempfile.create("commit_msg") do |f|
-      f.write(message)
-      f.flush
-      system("git commit -F #{f.path}", out: File::NULL, err: File::NULL)
-    end
+    commit_everything("Initial version")
+    tag_version(version)
   end
 
   def create_rakefile


### PR DESCRIPTION
The 0.5.0 release published a gem with no changelog entry of its own, under a tag reading `v0.4.23`. One cause, two symptoms: `reissue:bump` moves the version file forward and leaves everything else pointing at the old number.

| | Why it was wrong | Fix |
|---|---|---|
| **Changelog** | `Reissue.finalize` reads the version from the changelog's unreleased heading, never from the version file — so it dated the stale heading | The bump now points that heading at the version it landed on |
| **Tag** | Bundler loads the gemspec before the bump. `gem build` shells out and re-reads the file, so the *gem* was 0.5.0 while the tag came from the copy held in memory | The bump now sets the version on that cached spec |

Reloading the gemspec would not have fixed the tag: it reads its version through a memoised `require_relative`, so it hands back the same stale constant.

Fixed in the bump rather than in `finalize` so the repository is consistent *between* the two steps, and so standalone `rake reissue:finalize` keeps treating the changelog heading as authoritative.

### Why it surfaced now

`reissue:bump` is a no-op without a `Version:` trailer. It became a `build` prerequisite in b5a05b7 (2025-10-17), but this was the first release since carrying one — zero in each of the three preceding release ranges, one in this one.

### Verification

Both fixes driven by tests watched failing first. The tag test reported `1.2.3` for a `1.3.0` gem before the fix.

Beyond unit tests, a real `rake release` against a local remote with `gem_push=no`, from the state that triggers the bug:

| | Before | After |
|---|---|---|
| built | `pkg/reissue-0.5.0.gem` | `pkg/reissue-0.6.0.gem` |
| reported | `reissue 0.4.23 built` | `reissue 0.6.0 built` |
| tagged | `v0.4.23` | `v0.6.0` |
| changelog | `## [0.4.23]` | `## [0.6.0]` |

Suite: 205 runs, 648 assertions, 0 failures. Rebased onto main after #130/#131/#132 merged; the `rake.rb` conflict with #132's `next_release_version` was additive and both are kept.

### Still open

`test_release_integration.rb` documents this exact flow in comments — including "tag v2.0.0 created" — then asserts `assert true`. The contract was written down and never checked, which is much of why this shipped. The tests here cover it for real; those placeholders still assert nothing.