### PR TITLE
Preserve runbook preamble and seed a runbook from reissue:initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ Steps to perform after releasing the version below.
 - [ ] Re-index search documents (def5678)
 ```
 
+The title and the preamble beneath it are yours to edit. Give the file a custom heading and intro and reissue preserves them across finalize and new-version resets — only the version heading and the checklist are rewritten, the same way a custom preamble survives in `CHANGELOG.md`.
+
 ### Adding Runbook Items
 
 Add `Runbook:` trailers to commit messages (case-insensitive, independent of the `fragment` setting):

--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Reissue::Task.create :reissue do |task|
 end
 ```
 
+You don't have to create the file yourself — the first `rake reissue` or `rake reissue:finalize` writes it when `runbook_file` is set. To start from a template you can customize, run `rake reissue:initialize[runbook]`, which creates `RUNBOOK.md` (pass a different name, e.g. `rake reissue:initialize[OPERATIONS.md]`, to use another path).
+
 The runbook holds only the latest release. Items are checkboxes so operators can tick them off:
 
 ```markdown

--- a/lib/reissue/rake.rb
+++ b/lib/reissue/rake.rb
@@ -525,8 +525,8 @@ end
 # Define the reissue:initialize task as a standalone task
 # This works without any configuration, allowing users to bootstrap their project
 namespace :reissue do
-  desc "Initialize reissue by creating a CHANGELOG.md and showing Rakefile configuration"
-  task :initialize do
+  desc "Initialize reissue by creating a CHANGELOG.md and showing Rakefile configuration. Pass [runbook] to also create a RUNBOOK.md."
+  task :initialize, [:runbook] do |task, args|
     changelog_file = "CHANGELOG.md"
 
     if File.exist?(changelog_file)
@@ -534,6 +534,16 @@ namespace :reissue do
     else
       Reissue.generate_changelog(changelog_file)
       puts "✓ Created #{changelog_file}"
+    end
+
+    if args[:runbook]
+      runbook_file = (args[:runbook] == "runbook") ? "RUNBOOK.md" : args[:runbook]
+      if File.exist?(runbook_file)
+        puts "✓ #{runbook_file} already exists"
+      else
+        Reissue::Runbook.new(runbook_file).generate
+        puts "✓ Created #{runbook_file}"
+      end
     end
 
     puts
@@ -565,6 +575,7 @@ namespace :reissue do
 
         # Post-release runbook (mainly for applications)
         # task.runbook_file = "RUNBOOK.md"        # Maintain a runbook from Runbook: git trailers
+        #                                         # Seed a starter file with: rake reissue:initialize[runbook]
 
         # Git workflow options
         task.commit = true                        # Auto-commit version bumps

--- a/lib/reissue/runbook.rb
+++ b/lib/reissue/runbook.rb
@@ -6,15 +6,20 @@ module Reissue
   class Runbook
     ITEM_PATTERN = /^- (?:\[(?<checked>[ xX])\] )?(?<text>.+)$/
 
+    DEFAULT_TITLE = "Runbook"
+    DEFAULT_PREAMBLE = "Steps to perform after releasing the version below."
+
     def initialize(runbook_file)
       @runbook_file = runbook_file
     end
 
     attr_reader :runbook_file
 
-    # Writes a header-only template for the given version.
+    # Writes a header-only template for the given version, preserving any
+    # custom title and preamble already in the file.
     def generate(version: "Unreleased")
-      File.write(runbook_file, template(heading(version)))
+      title, preamble = parsed_header
+      File.write(runbook_file, template(heading(version), title:, preamble:))
     end
 
     alias_method :clear, :generate
@@ -25,17 +30,32 @@ module Reissue
     end
 
     # Stamps the header with the release version and date, merging directly
-    # edited items with trailer items (deduplicated by text).
+    # edited items with trailer items (deduplicated by text). Preserves any
+    # custom title and preamble already in the file.
     def finalize(version:, date:, trailer_items: [])
+      title, preamble = parsed_header
       merged = parsed_items
       texts = merged.map { |item| item[:text] }
       trailer_items.each do |text|
         merged << {text: text, checked: false} unless texts.include?(text)
       end
-      File.write(runbook_file, template(heading(version, date), merged))
+      File.write(runbook_file, template(heading(version, date), merged, title:, preamble:))
     end
 
     private
+
+    # Returns the [title, preamble] found before the first version heading,
+    # falling back to the defaults when the file is missing or header-only.
+    def parsed_header
+      return [DEFAULT_TITLE, DEFAULT_PREAMBLE] unless File.exist?(runbook_file)
+
+      header_chunk = File.read(runbook_file).split(/^## /, 2).first.to_s
+      title_match = header_chunk.match(/^#\s+(?<title>.+)$/)
+      title = title_match ? title_match[:title].strip : DEFAULT_TITLE
+      preamble = (title_match ? header_chunk.sub(title_match[0], "") : header_chunk).strip
+      preamble = DEFAULT_PREAMBLE if preamble.empty?
+      [title, preamble]
+    end
 
     def parsed_items
       return [] unless File.exist?(runbook_file)
@@ -51,11 +71,11 @@ module Reissue
       date ? "## [#{version}] - #{date}" : "## [#{version}]"
     end
 
-    def template(heading, items = [])
+    def template(heading, items = [], title: DEFAULT_TITLE, preamble: DEFAULT_PREAMBLE)
       header = <<~MARKDOWN
-        # Runbook
+        # #{title}
 
-        Steps to perform after releasing the version below.
+        #{preamble}
 
         #{heading}
       MARKDOWN

--- a/test/reissue/rake_initialize_test.rb
+++ b/test/reissue/rake_initialize_test.rb
@@ -81,6 +81,58 @@ module Reissue
       end
     end
 
+    def test_creates_runbook_when_runbook_argument_given
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          refute File.exist?("RUNBOOK.md")
+
+          output = capture_io { Rake::Task["reissue:initialize"].invoke("runbook") }.first
+
+          assert File.exist?("RUNBOOK.md"), "RUNBOOK.md should be created"
+          assert_match(/Created RUNBOOK\.md/, output)
+
+          content = File.read("RUNBOOK.md")
+          assert_match(/# Runbook/, content)
+          assert_match(/## \[Unreleased\]/, content)
+        end
+      end
+    end
+
+    def test_does_not_create_runbook_without_argument
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          capture_io { Rake::Task["reissue:initialize"].invoke }
+
+          refute File.exist?("RUNBOOK.md"), "RUNBOOK.md should not be created without the runbook argument"
+        end
+      end
+    end
+
+    def test_does_not_overwrite_existing_runbook
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          existing_content = "# My Runbook\n\nCustom operator notes.\n\n## [Unreleased]\n"
+          File.write("RUNBOOK.md", existing_content)
+
+          output = capture_io { Rake::Task["reissue:initialize"].invoke("runbook") }.first
+
+          assert_equal existing_content, File.read("RUNBOOK.md")
+          assert_match(/RUNBOOK\.md already exists/, output)
+        end
+      end
+    end
+
+    def test_creates_runbook_at_custom_filename
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          output = capture_io { Rake::Task["reissue:initialize"].invoke("OPERATIONS.md") }.first
+
+          assert File.exist?("OPERATIONS.md"), "custom runbook filename should be created"
+          assert_match(/Created OPERATIONS\.md/, output)
+        end
+      end
+    end
+
     def test_created_changelog_has_proper_format
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do

--- a/test/test_runbook.rb
+++ b/test/test_runbook.rb
@@ -71,6 +71,57 @@ class TestRunbook < Minitest::Spec
     end
   end
 
+  describe "preamble preservation" do
+    it "preserves a custom title and preamble when clearing" do
+      File.write(@tempfile.path, <<~MD)
+        # Deploy Runbook
+
+        These steps must be done by an operator with production access.
+        Tick them off as you go.
+
+        ## [1.2.3] - 2026-07-21
+
+        - [x] Run cleanup
+      MD
+      @runbook.clear
+
+      contents = File.read(@tempfile.path)
+      assert_match(/# Deploy Runbook/, contents)
+      assert_match(/These steps must be done by an operator with production access\./, contents)
+      assert_match(/Tick them off as you go\./, contents)
+      assert_match(/## \[Unreleased\]/, contents)
+      refute_match(/Run cleanup/, contents)
+    end
+
+    it "preserves a custom title and preamble when finalizing" do
+      File.write(@tempfile.path, <<~MD)
+        # Deploy Runbook
+
+        Operator-only steps.
+
+        ## [Unreleased]
+
+        - [ ] Rotate credentials
+      MD
+      @runbook.finalize(version: "1.2.3", date: "2026-07-21")
+
+      contents = File.read(@tempfile.path)
+      assert_match(/# Deploy Runbook/, contents)
+      assert_match(/Operator-only steps\./, contents)
+      assert_match(/## \[1\.2\.3\] - 2026-07-21/, contents)
+      assert_match(/- \[ \] Rotate credentials/, contents)
+    end
+
+    it "falls back to the default title and preamble for a header-only file" do
+      @runbook.generate
+      @runbook.clear
+
+      contents = File.read(@tempfile.path)
+      assert_match(/# Runbook/, contents)
+      assert_match(/Steps to perform after releasing the version below\./, contents)
+    end
+  end
+
   describe "finalize" do
     it "stamps the header with the version and date" do
       @runbook.generate


### PR DESCRIPTION
A runbook's title and preamble are the operator-facing context for a release, but reissue treated them as disposable: every clear or finalize rewrote the header from a fixed template, so a custom heading or intro survived only until the next release run. The changelog already round-trips a custom preamble; the runbook now does the same, rewriting only the version heading and the checklist.

Configuring `runbook_file` also gave no way to scaffold the file up front — it just appeared on the next release with the stock header, leaving nowhere to add that custom context before the first release. `reissue:initialize[runbook]` now writes a starter `RUNBOOK.md` (or a path you name) so there's a file to customize immediately, while the no-argument form stays changelog-only for the gem case.

The two concerns are split into their own commits.